### PR TITLE
Set ovn_central_ip to point to all central IPs by default.

### DIFF
--- a/browbeat-scenarios/osh_workload_incremental.json
+++ b/browbeat-scenarios/osh_workload_incremental.json
@@ -5,7 +5,7 @@
 {% set gw_batch_ops = gw_batch_ops or False %}
 {% set ovn_monitor_all = ovn_monitor_all or True %}
 {% set ovn_cluster_db = ovn_cluster_db or True %}
-{% set ovn_central_ip = ovn_central_ip or "192.16.0.1" %}
+{% set ovn_central_ip = ovn_central_ip or "192.16.0.1-192.16.0.2-192.16.0.3" %}
 {% set cluster_cmd_path = cluster_cmd_path or "/root/ovn-fake-testing/ovn-fake-multinode" %}
 {% set node_batch_size = node_batch_size or 1 %}
 {% set sla = sla or 30 %}

--- a/browbeat-scenarios/switch-per-node-300.yml
+++ b/browbeat-scenarios/switch-per-node-300.yml
@@ -68,4 +68,3 @@ workloads:
         farm_nodes: 300
         ports_per_network: 300
         cluster_cmd_path: /root/ovn-heater/runtime/ovn-fake-multinode
-        ovn_central_ip: "192.16.0.1-192.16.0.2-192.16.0.3"

--- a/browbeat-scenarios/switch-per-node-500.yml
+++ b/browbeat-scenarios/switch-per-node-500.yml
@@ -68,4 +68,3 @@ workloads:
         farm_nodes: 500
         ports_per_network: 500
         cluster_cmd_path: /root/ovn-heater/runtime/ovn-fake-multinode
-        ovn_central_ip: "192.16.0.1-192.16.0.2-192.16.0.3"

--- a/browbeat-scenarios/switch-per-node-low-scale-batch2.yml
+++ b/browbeat-scenarios/switch-per-node-low-scale-batch2.yml
@@ -69,4 +69,3 @@ workloads:
         node_batch_size: 2
         ports_per_network: 1
         cluster_cmd_path: /root/ovn-heater/runtime/ovn-fake-multinode
-        ovn_central_ip: "192.16.0.1-192.16.0.2-192.16.0.3"

--- a/browbeat-scenarios/switch-per-node-low-scale.yml
+++ b/browbeat-scenarios/switch-per-node-low-scale.yml
@@ -68,4 +68,3 @@ workloads:
         farm_nodes: 2
         ports_per_network: 2
         cluster_cmd_path: /root/ovn-heater/runtime/ovn-fake-multinode
-        ovn_central_ip: "192.16.0.1-192.16.0.2-192.16.0.3"


### PR DESCRIPTION
By default we start all tests with NB/SB DBs clustered. Make
configuration less error prone by setting ovn_central_ip to point to all
central IPs by default.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>