### PR TITLE
do.sh: Clone projects into correct directories.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -86,7 +86,7 @@ function clone_component() {
     else
         rm -rf ${comp_name}
         echo "-- Cloning ${comp_name} from ${comp_repo} at revision ${comp_branch}"
-        git clone ${comp_repo}
+        git clone ${comp_repo} ${comp_name}
         pushd ${comp_name}
         git checkout ${comp_branch}
         popd


### PR DESCRIPTION
"git clone" uses the repo name as the default name for the directory
it creates.  This is right for the default repos, but users might
override the repo with one that has a different name, in which case
the default will be wrong.

By specifying the directory name explicitly like this, it will always
work properly.

I had this problem when I tried to use my ovs-reviews repo for OVS
and OVN.

Signed-off-by: Ben Pfaff <blp@ovn.org>