### PR TITLE
do.sh: Use docker-ce when available.

### DIFF
--- a/ovn-fake-multinode-utils/playbooks/configure-docker-registry.yml
+++ b/ovn-fake-multinode-utils/playbooks/configure-docker-registry.yml
@@ -15,4 +15,3 @@
   - name: Restart docker
     shell: |
       systemctl restart docker
-      systemctl restart docker-distribution

--- a/ovn-fake-multinode-utils/playbooks/install-dependencies.yml
+++ b/ovn-fake-multinode-utils/playbooks/install-dependencies.yml
@@ -4,4 +4,4 @@
     - name: Install required packages
       shell: yum install git gcc openvswitch python3-pyyaml python3-virtualenv python3-devel  --skip-broken -y
     - name: Install container command
-      shell: yum install docker docker-distribution -y || yum install podman podman-docker -y
+      shell: yum install docker-ce --nobest -y || yum install docker -y || yum install podman podman-docker -y


### PR DESCRIPTION
This enables users to use docker on platforms where docker is not
officially supported, e.g., RHEL8.

Also, remove dependency on docker-distribution. Instead just start a
container that runs the registry on the tester node.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>