### PR TITLE
Add new "scale-pods" scenario.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,33 @@ providing `ext_cmd_start` and `ext_cmd_stop` in `switch-per-node-100.yml`
 Results will be stored in `~ovn-heater/test_results/test-100-<date>/logs/<node>-perf/` for each
 container.
 
+## Example (run "scenario #3 - scale up number of pods - stress ovn-northd"):
+
+This simulates bringing up 30 `OVN` nodes and binding 1000 pods (logical
+ports), distributed across nodes. The test also configures port_groups,
+address_sets and ACLs for all pods simulating a network policy that would
+allow traffic.
+
+The test is meant to check `ovn-northd` performance so each iteration is
+considered successful if `ovn-northd` populated the
+Southbound DB, and the logical port is up (`up` is set to `true`).
+
+```
+cd ~/ovn-heater
+./do.sh browbeat-run browbeat-scenarios/switch-per-node-30-node-1000-pods.yml test-scale-pods
+```
+
+If needed, the number of simulated nodes and total number of simulated pods
+can be tweaked, by changing the following fields in
+`browbeat-scenarios/switch-per-node-30-node-1000-pods.yml`:
+
+```
+farm_nodes: <node-count>
+ports_per_network: <total-number-of-pods>
+port_wait_type: "none"
+port_internal_vm: "False"
+```
+
 ## Scenario execution with DBs in standalone mode
 
 By default tests configure NB/SB ovsdb-servers to run in clustered mode

--- a/browbeat-scenarios/osh_workload_incremental.json
+++ b/browbeat-scenarios/osh_workload_incremental.json
@@ -10,6 +10,9 @@
 {% set sla = sla or 30 %}
 {% set ext_cmd_start = ext_cmd_start or -1 %}
 {% set ext_cmd_stop = ext_cmd_stop or -1 %}
+{% set port_wait_type = port_wait_type or "ping" %}
+{% set port_wait_up = port_wait_up or True %}
+{% set port_internal_vm = port_internal_vm or True %}
 {
     "version": 2,
     "title": "Switch per node workload",
@@ -94,8 +97,9 @@
                         },
                         "port_bind_args": {
                             "internal" : true,
-                            "wait_up" : true,
-                            "wait_sync" : "ping",
+                            "internal_vm" : {{port_internal_vm}},
+                            "wait_up" : {{port_wait_up}},
+                            "wait_sync" : {{port_wait_type}},
                             "batch" : false
                         }
                     },
@@ -143,8 +147,9 @@
                         },
                         "port_bind_args": {
                             "internal" : true,
-                            "wait_up" : true,
-                            "wait_sync" : "ping",
+                            "internal_vm" : {{port_internal_vm}},
+                            "wait_up" : {{port_wait_up}},
+                            "wait_sync" : "{{port_wait_type}}",
                             "batch" : false
                         },
                         "name_space_size": 2,

--- a/browbeat-scenarios/switch-per-node-30-node-1000-pods.yml
+++ b/browbeat-scenarios/switch-per-node-30-node-1000-pods.yml
@@ -1,0 +1,71 @@
+browbeat:
+  cloud_name: openstack
+  rerun: 1
+  # Two types of rerun:
+  # iteration reruns on the iteration
+  # complete reruns after all workloads complete
+  # rerun_type: complete
+  rerun_type: iteration
+ansible:
+  hosts: ansible/hosts
+  metadata_playbook: ansible/gather/stockpile.yml
+  ssh_config: ansible/ssh-config
+elasticsearch:
+  enabled: false
+  host: 1.1.1.1
+  port: 9200
+  regather: false
+  metadata_files:
+    - name: hardware-metadata
+      file: metadata/hardware-metadata.json
+    - name: environment-metadata
+      file: metadata/environment-metadata.json
+    - name: software-metadata
+      file: metadata/software-metadata.json
+    - name: version
+      file: metadata/version.json
+grafana:
+  enabled: false
+  host: example.grafana.com
+  port: 3000
+  dashboards:
+    - openstack-general-system-performance
+rally:
+  sleep_before: 5
+  sleep_after: 5
+  plugins:
+    - glance: rally/rally-plugins/glance
+    - neutron: rally/rally-plugins/neutron
+    - netcreate-boot: rally/rally-plugins/netcreate-boot
+    - workloads: rally/rally-plugins/workloads
+    - rally-ovs: rally/ovs/scenarios
+shaker:
+  server: 1.1.1.1
+  port: 5555
+  flavor: m1.small
+  join_timeout: 600
+  sleep_before: 0
+  sleep_after: 0
+  shaker_region: regionOne
+  external_host: 2.2.2.2
+
+workloads:
+  # Rally ovs
+  - name: plugin-workloads
+    enabled: true
+    type: rally-ovs
+    concurrency:
+      - 1
+    times: 1
+    scenarios:
+      - name: switch-per-node-workload
+        enabled: true
+        file: ../../browbeat-scenarios/osh_workload_incremental.json
+        farm_node: ovn-farm-node-0
+        controller: ovn-controller-node
+        start_cidr: 192.168.33.10/24
+        farm_nodes: 30
+        ports_per_network: 1000
+        port_wait_type: "none"
+        port_internal_vm: "False"
+        cluster_cmd_path: /root/ovn-heater/runtime/ovn-fake-multinode


### PR DESCRIPTION
Also make it configurable if logical ports should be bound to network
namespaces. In some cases, e.g., when testing ovn-northd performance,
this is not needed.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>