### PR TITLE
Remove batching for initialization workload.

### DIFF
--- a/browbeat-scenarios/osh_workload_incremental.json
+++ b/browbeat-scenarios/osh_workload_incremental.json
@@ -79,7 +79,7 @@
                             "ovn_monitor_all": {{ovn_monitor_all}},
                             "ovn_cluster_db": {{ovn_cluster_db}},
                             "max_timeout_s": 10,
-                            "batch_size": {{farm_nodes}}
+                            "batch_size": 1
                         },
                         "lnetwork_create_args": {
                             "start_ext_cidr": "3.0.0.0/16",
@@ -88,7 +88,7 @@
                     },
                     "runner": {
                         "type": "serial",
-                        "times": 1
+                        "times": {{farm_nodes}}
                     },
                     "context": {
                         "ovn_multihost": {


### PR DESCRIPTION
Due to a problem in rally-ovs, a new persistent connection is created
for every new fake chassis.  This can cause problems at scale, e.g.,
running out of file descriptors while initiating 500 fake nodes.

For now disable batching.

This should be revisited once the rally-ovs persistent connection issue
is fixed.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>