### PR TITLE
scenarios: Make logical-dp-groups and SB raft timeout configurable.

### DIFF
--- a/browbeat-scenarios/osh_workload_incremental.json
+++ b/browbeat-scenarios/osh_workload_incremental.json
@@ -13,6 +13,8 @@
 {% set port_wait_type = port_wait_type or "ping" %}
 {% set port_wait_up = port_wait_up or True %}
 {% set port_internal_vm = port_internal_vm or True %}
+{% set use_dp_groups = use_dp_groups or True %}
+{% set sb_raft_election_to = sb_raft_election_to or 16 %}
 {
     "version": 2,
     "title": "Switch per node workload",
@@ -64,6 +66,62 @@
                 }
             ]
         },
+        {
+            "title": "Configure dp_groups",
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.ovn_run_command",
+                    "args": {
+                        "ext_cmd_args": {
+                            "start_cmd" : {
+                                "iter" : 0,
+                                "cmd": "ovn-nbctl --no-leader-only set NB_Global . options:use_logical_dp_groups={{use_dp_groups}}",
+                                "controller_pid_name": "ovn-northd",
+                            }
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% for timeout in range(1000, (sb_raft_election_to + 1) * 1000, 1000) %}
+        {
+            "title": "Configure RAFT election timeout",
+            "workloads": [
+                {
+                    "name": "OvnNorthbound.ovn_run_command",
+                    "args": {
+                        "ext_cmd_args": {
+                            "start_cmd" : {
+                                "iter" : 0,
+                                "cmd": "ovs-appctl -t /run/ovn/ovnsb_db.ctl cluster/change-election-timer OVN_Southbound {{timeout}}",
+                                "controller_pid_name": "ovn-northd",
+                            }
+                        }
+                    },
+                    "runner": {
+                        "type": "serial",
+                        "times": 1
+                    },
+                    "context": {
+                        "ovn_multihost": {
+                            "controller": "ovn-controller-node"
+                        },
+                        "sandbox": { "tag": "ToR1" }
+                    }
+                }
+            ]
+        },
+        {% endfor %}
         {
             "title": "Initialize switch_per_node scenario (setup workload)",
             "workloads": [


### PR DESCRIPTION
Signed-off-by: Dumitru Ceara <dceara@redhat.com>