### PR TITLE
Add Load Balancer API and use it to create cluster load balancer during cluster bring-up

### DIFF
--- a/ovn-tester/ovn_load_balancer.py
+++ b/ovn-tester/ovn_load_balancer.py
@@ -1,0 +1,76 @@
+import ovn_utils
+
+VALID_PROTOCOLS=['tcp', 'udp', 'sctp']
+
+class InvalidProtocol(Exception):
+    def __init__(self, invalid_protocols):
+        self.args = invalid_protocols
+
+    def __str__(self):
+        return f"Invalid Protocol: {self.args}"
+
+class OvnLoadBalancer(object):
+    def __init__(self, lb_name, nbctl, vips=None, protocols=VALID_PROTOCOLS):
+        '''
+        Create load balancers with optional vips.
+        lb_name: String used as basis for load balancer name.
+        nbctl: Connection used for ovn-nbctl commands
+        vips: Optional dictionary mapping VIPs to a list of backend IPs.
+        protocols: List of protocols to use when creating Load Balancers.
+        '''
+        self.nbctl = nbctl
+        self.protocols = [prot for prot in protocols if prot in VALID_PROTOCOLS]
+        if len(self.protocols) == 0:
+            raise InvalidProtocol(protocols)
+        self.name = lb_name
+        self.vips = {}
+        self.lbs = []
+        for protocol in self.protocols:
+            self.lbs.append(self.nbctl.create_lb(self.name, protocol))
+        if vips:
+            self.add_vips(vips)
+
+    def add_vips(self, vips):
+        '''
+        Add VIPs to a load balancer.
+        vips: Dictionary with key being a VIP string, and value being a list of
+        backend IP address strings. It's perfectly acceptable for the VIP to
+        have no backends.
+        '''
+        for vip, backends in vips.items():
+            cur_backends = self.vips.setdefault(vip, [])
+            if backends:
+                cur_backends.extend(backends)
+
+        for lb in self.lbs:
+            self.nbctl.lb_set_vips(lb['uuid'], self.vips)
+
+    def add_backends_to_vip(self, backends, vips=None):
+        '''
+        Add backends to existing load balancer VIPs.
+        backends: A list of IP addresses to add as backends to VIPs.
+        vips: A list of VIPs to which backends should be added. If this is
+        'None' then the backends are added to all VIPs.
+        '''
+        for cur_vip, cur_backends in self.vips.items():
+            if not vips or cur_vip in vips:
+                cur_backends.extend(backends)
+
+        for lb in self.lbs:
+            self.nbctl.lb_set_vips(lb['uuid'], self.vips)
+
+    def add_to_router(self, router):
+        for lb in self.lbs:
+            self.nbctl.lb_add_to_router(lb['uuid'], router)
+
+    def add_to_switch(self, switch):
+        for lb in self.lbs:
+            self.nbctl.lb_add_to_switch(lb['uuid'], switch)
+
+    def remove_from_router(self, router):
+        for lb in self.lbs:
+            self.nbctl.lb_remove_from_router(lb['uuid'], router)
+
+    def remove_from_switch(self, switch):
+        for lb in self.lbs:
+            self.nbctl.lb_remove_from_switch(lb['uuid'], switch)

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -220,6 +220,37 @@ class OvnNbctl:
                                               external_ip, logical_ip)
         self.run(cmd=cmd)
 
+    def create_lb(self, name, protocol):
+        lb_name = f"{name}-{protocol}"
+        cmd = f"create Load_Balancer name={lb_name} protocol={protocol}"
+
+        stdout = StringIO()
+        self.run(cmd=cmd, stdout=stdout)
+        return {'name': lb_name, 'uuid': stdout.getvalue().strip()}
+
+    def lb_set_vips(self, lb_uuid, vips):
+        vip_str = ''
+        for vip, backends in vips.items():
+            vip_str += f'vips:\\"{vip}\\"=\\"{",".join(backends)}\\" '
+        cmd = f"set Load_Balancer {lb_uuid} {vip_str}"
+        self.run(cmd=cmd)
+
+    def lb_add_to_router(self, lb_uuid, router):
+        cmd = f"lr-lb-add {router} {lb_uuid}"
+        self.run(cmd=cmd)
+
+    def lb_add_to_switch(self, lb_uuid, switch):
+        cmd = f"ls-lb-add {switch} {lb_uuid}"
+        self.run(cmd=cmd)
+
+    def lb_remove_from_router(self, lb_uuid, router):
+        cmd = f"lr-lb-del {router} {lb_uuid}"
+        self.run(cmd=cmd)
+
+    def lb_remove_from_switch(self, lb_uuid, switch):
+        cmd = f"ls-lb-del {switch} {lb_uuid}"
+        self.run(cmd=cmd)
+
     def wait_until(self, cmd=""):
         self.run("wait-until " + cmd)
 


### PR DESCRIPTION
This is part one of a series that seeks to update the bring-up scenario to be closer to our scale testing goals.

In this series of commits:
Commit 1: Introduces a Load Balancer API.
Commit 2: Uses the API to create a cluster load balancer and add some initial VIPs to it.

These commits do not add per-node load balancers, nor do they update the cluster load balancers after initial creation. This is because the refactor that this patch is based off does not have the node-specific bring-up defined. This is best left until the rest of the code has been refactored.