### PR TITLE
ovn-tester: Add multitenant network policy-like tests.

### DIFF
--- a/test-scenarios/ovn-500.yml
+++ b/test-scenarios/ovn-500.yml
@@ -7,4 +7,17 @@ cluster:
   n_workers: 500
 
 base_cluster_bringup:
-  n_pods_per_node: 2
+  n_pods_per_node: 10
+
+netpol_multitenant:
+  n_namespaces: 500
+  ranges:
+    - r1:
+      start:   200
+      n_pods:  5
+    - r2:
+      start:   480
+      n_pods:  20
+    - r3:
+      start:   495
+      n_pods:  100

--- a/test-scenarios/ovn-low-scale.yml
+++ b/test-scenarios/ovn-low-scale.yml
@@ -8,3 +8,16 @@ cluster:
 
 base_cluster_bringup:
   n_pods_per_node: 2
+
+netpol_multitenant:
+  n_namespaces: 5
+  ranges:
+    - r1:
+      start:   2
+      n_pods:  2
+    - r2:
+      start:   3
+      n_pods:  5
+    - r3:
+      start:   4
+      n_pods: 10


### PR DESCRIPTION
Allows scale testing OpenShift multitenant network policy-like
scenarios, for example, the equivalent of:

```
for i in range(n_namespaces):
    create address set AS_ns_i
    create port group PG_ns_i
    if i < 200:
        n_pods = 1 # 200 pods
    elif i < 480:
        n_pods = 5 # 1400 pods
    elif i < 495:
        n_pods = 20 # 300 pods
    else:
        n_pods = 100 # 500 pods
    create n_pods
    add n_pods to AS_ns_i
    add n_pods to PG_ns_i
    create acls:

    to-lport, ip.src == $AS_ns_i && outport == @PG_ns_i, allow-related
    to-lport, ip.src == {ip1, ip2, ip3} && outport == @PG_ns_i, allow-related
    to-lport, ip.src == {ip1, ..., ip20} && outport == @PG_ns_i, allow-related
```

Signed-off-by: Dumitru Ceara <dceara@redhat.com>