### PR TITLE
ovn_load_balancer: Only update changed VIPs.

### DIFF
--- a/ovn-tester/ovn_load_balancer.py
+++ b/ovn-tester/ovn_load_balancer.py
@@ -41,13 +41,15 @@ class OvnLoadBalancer(object):
         backend IP address strings. It's perfectly acceptable for the VIP to
         have no backends.
         '''
+        updated_vips = {}
         for vip, backends in vips.items():
             cur_backends = self.vips.setdefault(vip, [])
             if backends:
                 cur_backends.extend(backends)
+            updated_vips[vip] = cur_backends
 
         for lb in self.lbs:
-            self.nbctl.lb_set_vips(lb.uuid, self.vips)
+            self.nbctl.lb_set_vips(lb.uuid, updated_vips)
 
     def clear_vips(self):
         '''


### PR DESCRIPTION
There's no need to set all VIPs in a load balancer, it's enough to only
update the ones that actually changed.  Otherwise, ovn-nbctl ends up
creating increasingly large NB transactions when there's no need to do
that.

From what I see, OpenShift already does this, but needs more
investigation to confirm.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>