### PR TITLE
ovn-tester: Set NB/SB inactivity_probe.

### DIFF
--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -107,6 +107,7 @@ def read_config(configuration):
             logical_dp_groups=cluster_args.get('logical_dp_groups', True),
             clustered_db=cluster_args.get('clustered_db', True),
             raft_election_to=cluster_args.get('raft_election_to', 16),
+            db_inactivity_probe=cluster_args.get('db_inactivity_probe', 60000),
             node_net=netaddr.IPNetwork(
                 cluster_args.get('node_net', '192.16.0.0/16')
             ),

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -65,6 +65,9 @@ class OvnNbctl:
     def set_global(self, option, value):
         self.run(f'set NB_Global . options:{option}={value}')
 
+    def set_inactivity_probe(self, value):
+        self.run(f'set Connection . inactivity_probe={value}')
+
     def lr_add(self, name):
         print(f'***** creating lrouter {name} *****')
         self.run(cmd=f'lr-add {name}')
@@ -233,6 +236,9 @@ class OvnSbctl:
 
     def run(self, cmd="", stdout=None):
         self.sb.run(cmd="ovn-sbctl --no-leader-only " + cmd, stdout=stdout)
+
+    def set_inactivity_probe(self, value):
+        self.run(f'set Connection . inactivity_probe={value}')
 
     def chassis_bound(self, chassis=""):
         cmd = f'--bare --columns _uuid find chassis name={chassis}'

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -21,6 +21,7 @@ ClusterConfig = namedtuple('ClusterConfig',
                             'logical_dp_groups',
                             'clustered_db',
                             'raft_election_to',
+                            'db_inactivity_probe',
                             'node_net',
                             'node_remote',
                             'node_timeout_s',
@@ -466,6 +467,8 @@ class Cluster(object):
             'use_logical_dp_groups',
             self.cluster_cfg.logical_dp_groups
         )
+        self.nbctl.set_inactivity_probe(self.cluster_cfg.db_inactivity_probe)
+        self.sbctl.set_inactivity_probe(self.cluster_cfg.db_inactivity_probe)
 
     def create_cluster_router(self, rtr_name):
         self.router = self.nbctl.lr_add(rtr_name)


### PR DESCRIPTION
Make the DB inactivity probe configurable and set it to 60 seconds by
default to mimic what OpenShift does.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>