### PR TITLE
ovn_tester: Make OVS datapath type configurable.

### DIFF
--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -88,6 +88,7 @@ def read_config(config):
         monitor_all=cluster_args.get('monitor_all', True),
         logical_dp_groups=cluster_args.get('logical_dp_groups', True),
         clustered_db=cluster_args.get('clustered_db', True),
+        datapath_type=cluster_args.get('datapath_type', 'system'),
         raft_election_to=cluster_args.get('raft_election_to', 16),
         node_net=netaddr.IPNetwork(
             cluster_args.get('node_net', '192.16.0.0/16')

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -20,6 +20,7 @@ ClusterConfig = namedtuple('ClusterConfig',
                             'monitor_all',
                             'logical_dp_groups',
                             'clustered_db',
+                            'datapath_type',
                             'raft_election_to',
                             'db_inactivity_probe',
                             'node_net',
@@ -51,6 +52,7 @@ class Node(ovn_sandbox.Sandbox):
         cmd = \
             f'cd {cluster_cfg.cluster_cmd_path} && ' \
             f'OVN_MONITOR_ALL={monitor_all} OVN_DB_CLUSTER={clustered_db} ' \
+            f'OVN_DP_TYPE={cluster_cfg.datapath_type} ' \
             f'CREATE_FAKE_VMS=no CHASSIS_COUNT=0 GW_COUNT=0 '\
             f'IP_HOST={self.mgmt_net.ip} ' \
             f'IP_CIDR={self.mgmt_net.prefixlen} ' \

--- a/test-scenarios/ocp-120-cluster-density-netdev.yml
+++ b/test-scenarios/ocp-120-cluster-density-netdev.yml
@@ -1,0 +1,15 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  datapath_type: netdev
+  monitor_all: true
+  n_workers: 120
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+cluster_density:
+  n_startup: 800
+  n_runs: 1000

--- a/test-scenarios/ocp-20-cluster-density-netdev.yml
+++ b/test-scenarios/ocp-20-cluster-density-netdev.yml
@@ -1,0 +1,15 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  datapath_type: netdev
+  monitor_all: true
+  n_workers: 20
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+cluster_density:
+  n_startup: 400
+  n_runs: 500


### PR DESCRIPTION
Default is still "system".

Signed-off-by: Dumitru Ceara <dceara@redhat.com>