### PR TITLE
ovn-tester: Add support for ovsdb relays.

### DIFF
--- a/ovn-fake-multinode-utils/scripts/log-collector.sh
+++ b/ovn-fake-multinode-utils/scripts/log-collector.sh
@@ -31,6 +31,14 @@ for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-central"); do
     docker cp $c:/var/log/openvswitch/ovn-nbctl.log ${host}/$c/
 done
 
+for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-relay"); do
+    mkdir ${host}/$c
+    docker exec $c ps -aux > ${host}/$c/ps-before-compaction
+    docker exec $c ovs-appctl --timeout=30 -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/compact
+    docker exec $c ps -aux > ${host}/$c/ps-after-compaction
+    docker cp $c:/var/log/ovn/ovsdb-server-sb.log ${host}/$c/
+done
+
 journalctl --since "8 hours ago" -a > ${host}/messages
 
 tar cvfz ${host}.tgz ${host}

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -31,6 +31,7 @@ ClusterConfig = namedtuple('ClusterConfig',
                             'gw_net',
                             'cluster_net',
                             'n_workers',
+                            'n_relays',
                             'vips',
                             'vip_subnet',
                             'static_vips'])
@@ -54,6 +55,7 @@ class Node(ovn_sandbox.Sandbox):
             f'OVN_MONITOR_ALL={monitor_all} OVN_DB_CLUSTER={clustered_db} ' \
             f'OVN_DP_TYPE={cluster_cfg.datapath_type} ' \
             f'CREATE_FAKE_VMS=no CHASSIS_COUNT=0 GW_COUNT=0 '\
+            f'RELAY_COUNT={cluster_cfg.n_relays} '\
             f'IP_HOST={self.mgmt_net.ip} ' \
             f'IP_CIDR={self.mgmt_net.prefixlen} ' \
             f'IP_START={self.mgmt_ip} ' \

--- a/test-scenarios/ovn-low-scale.yml
+++ b/test-scenarios/ovn-low-scale.yml
@@ -5,6 +5,7 @@ cluster:
   clustered_db: true
   monitor_all: true
   n_workers: 2
+  n_relays: 3
 
 base_cluster_bringup:
   n_pods_per_node: 2


### PR DESCRIPTION
Support for OVSDB Relays was added to OVS in commit:
  https://github.com/openvswitch/ovs/commit/026c77c58ddba12ad81082ca27564ab9c33986bd
and will be part of 2.16 release.  Adding support to test 2-Tier Sb DB
setups with configurable number of relays.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>

Depends on a following change in ovn-fake-multinode:
  https://github.com/ovn-org/ovn-fake-multinode/pull/44