### PR TITLE
ovn-tester: Set northd probe interval.

### DIFF
--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -110,6 +110,7 @@ def read_config(config):
             'node_remote',
             calculate_default_node_remotes(node_net, clustered_db, n_relays)
         ),
+        northd_probe_interval=cluster_args.get('northd_probe_interval', 5000),
         db_inactivity_probe=cluster_args.get('db_inactivity_probe', 60000),
         node_timeout_s=cluster_args.get('node_timeout_s', 20),
         internal_net=netaddr.IPNetwork(

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -18,6 +18,7 @@ ClusterConfig = namedtuple('ClusterConfig',
                             'clustered_db',
                             'datapath_type',
                             'raft_election_to',
+                            'northd_probe_interval',
                             'db_inactivity_probe',
                             'node_net',
                             'node_remote',
@@ -538,6 +539,10 @@ class Cluster(object):
         self.nbctl.set_global(
             'use_logical_dp_groups',
             self.cluster_cfg.logical_dp_groups
+        )
+        self.nbctl.set_global(
+            'northd_probe_interval',
+            self.cluster_cfg.northd_probe_interval
         )
         self.nbctl.set_inactivity_probe(self.cluster_cfg.db_inactivity_probe)
         self.sbctl.set_inactivity_probe(self.cluster_cfg.db_inactivity_probe)


### PR DESCRIPTION
Default 5000ms (as currently configured by OpenShift).

Signed-off-by: Dumitru Ceara <dceara@redhat.com>