### PR TITLE
ovn-heater: Be kind to third party containers

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -60,7 +60,9 @@ function install_deps() {
     yum install redhat-lsb-core python3-pip python3-virtualenv python3 python3-devel python-virtualenv --skip-broken -y
     [ -e /usr/bin/pip ] || ln -sf /usr/bin/pip3 /usr/bin/pip
 
-    for container_name in `docker ps | grep -v "CONTAINER ID" | awk '{print $1}'`
+    containers=$(docker ps --filter='name=(ovn|registry)' \
+                        | grep -v "CONTAINER ID" | awk '{print $1}')
+    for container_name in $containers
     do
         docker stop $container_name
         docker rm $container_name

--- a/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
+++ b/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
@@ -8,9 +8,8 @@
       state: started
 
   - name: Delete old docker volumes
-    file:
-      path: /var/lib/docker/volumes/
-      state: absent
+    shell: |
+      docker volume prune -f
 
   - name: Delete old docker containers if any
     shell: |


### PR DESCRIPTION
These changes make ovn-heater to respect docker containers not created by it.
For example, this is be required if user wants to run graphana/graphite container
on the central node (which is the same as management node in a single host setup).