### PR TITLE
Set gateway chassis for each cluster router port.

### DIFF
--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -77,6 +77,10 @@ class OvnNbctl:
         self.run(cmd=f'lrp-add {router.name} {name} {mac} {ip}/{plen}')
         return LRPort(name=name)
 
+    def lr_port_set_gw_chassis(self, rp, chassis, priority=10):
+        print(f'** Setting gw chassis {chassis} for router port {rp.name} **')
+        self.run(cmd=f'lrp-set-gateway-chassis {rp.name} {chassis} {priority}')
+
     def ls_add(self, name, cidr):
         print(f'***** creating lswitch {name} *****')
         self.run(cmd=f'ls-add {name}')

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -175,6 +175,9 @@ class WorkerNode(Node):
             self.switch, ls_rp_name, self.rp
         )
 
+        # Make the lrp as distributed gateway router port.
+        cluster.nbctl.lr_port_set_gw_chassis(self.rp, self.container)
+
         # Create a gw router and connect it to the cluster join switch.
         self.gw_router = cluster.nbctl.lr_add(f'gwrouter-{self.container}')
         cluster.nbctl.run(f'set Logical_Router {self.gw_router.name} '


### PR DESCRIPTION
OVN supports creating multiple gw router ports for a logical router.
This support was added to improve the scalability.  Make use of it.
A gateway chassis is created for each router port of the cluster router
with the node chassis as gateway chassis.

Signed-off-by: Numan Siddique <nusiddiq@redhat.com>