### PR TITLE
do.sh: Collect data about poll intervals and database compactions.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -57,7 +57,9 @@ function install_deps() {
     else
         yum install -y podman podman-docker
     fi
-    yum install redhat-lsb-core python3-pip python3-virtualenv python3 python3-devel python-virtualenv --skip-broken -y
+    yum install redhat-lsb-core datamash \
+        python3-pip python3-virtualenv python3 python3-devel python-virtualenv \
+        --skip-broken -y
     [ -e /usr/bin/pip ] || ln -sf /usr/bin/pip3 /usr/bin/pip
 
     containers=$(docker ps --filter='name=(ovn|registry)' \
@@ -298,6 +300,16 @@ function run_test() {
        tar xvfz $f
     done
     popd
+
+    mkdir -p mined-data
+    for p in ovn-northd ovn-controller ovn-nbctl; do
+        logs=$(find ${out_dir}/logs -name ${p}.log)
+        ${topdir}/utils/mine-poll-intervals.sh ${logs} > mined-data/${p}
+    done
+    for p in ovsdb-server-sb ovsdb-server-nb; do
+        logs=$(find ${out_dir}/logs -name ${p}.log)
+        ${topdir}/utils/mine-db-poll-intervals.sh ${logs} > mined-data/${p}
+    done
 
     deactivate
     popd

--- a/utils/mine-db-poll-intervals.sh
+++ b/utils/mine-db-poll-intervals.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+function mine_data_for_poll_intervals {
+    res=$(echo "$1" \
+        | sed '/\(writes\|involuntary\)/s/$/\n\n/' \
+        | egrep -A 2 -B 1 'Unreasonably' \
+        | grep -v '\-\-' | cut -c 45- | paste -d " " - - - - \
+        | sed 's/.*took \([0-9]*\)ms .*long \([0-9]*\)ms .* \([0-9]*\)ms system.* \([0-9]*\) writes.*/\2 \3 \4 compaction \1/' \
+        | sed 's/.*long \([0-9]*\)ms .* \([0-9]*\)ms system.*/\1 \2/' \
+        | sort -h | grep -v compaction | cut -f 1 -d ' ' \
+        | datamash count 1 min 1 max 1 median 1 mean 1 perc 1 \
+                   -t ' '  --format="%10.1f" )
+    if [ -z "$res" ]; then
+        printf "%10.1f\n" 0
+    else
+        echo "$res"
+    fi
+}
+
+function mine_data_for_compaction {
+    res=$(echo "$1" \
+        | grep 'compaction took' | cut -c 43- \
+        | sed 's/.*Database compaction took \(.*\)ms/\1/' | sort -h \
+        | datamash count 1 min 1 max 1 median 1 mean 1 perc 1 \
+                   -t ' '  --format="%10.1f" )
+    if [ -z "$res" ]; then
+        printf "%10.1f\n" 0
+    else
+        echo "$res"
+    fi
+}
+
+n_files=$#
+echo
+echo "Unreasonably long poll intervals that didn't involve database compaction:"
+echo
+echo "Note:"
+echo "It's not possible to exclude compactions under 1 second long, so these,"
+echo "if any, are accounted in below statistics.  Mistakes are also possible."
+echo
+echo "---------------------------------------------------------------------"
+echo "     Count      Min        Max       Median      Mean   95 percentile"
+echo "---------------------------------------------------------------------"
+
+for file in "$@"; do
+    mine_data_for_poll_intervals "$(cat $file)"
+done
+
+if test ${n_files} -gt 1; then
+    echo "---------------------------------------------------------------------"
+    mine_data_for_poll_intervals "$(cat $@)"
+fi
+echo
+
+echo "Database compaction:"
+echo
+echo "Note: Compactions under 1 second long are not counted."
+echo
+echo "---------------------------------------------------------------------"
+echo "     Count      Min        Max       Median      Mean   95 percentile"
+echo "---------------------------------------------------------------------"
+
+for file in "$@"; do
+    mine_data_for_compaction "$(cat $file)"
+done
+
+if test ${n_files} -gt 1; then
+    echo "---------------------------------------------------------------------"
+    mine_data_for_compaction "$(cat $@)"
+fi
+echo

--- a/utils/mine-poll-intervals.sh
+++ b/utils/mine-poll-intervals.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function mine_data_for_poll_intervals {
+    res=$(echo "$1" \
+        | grep 'Unreasonably' | cut -c 45- \
+        | sed 's/.*Unreasonably long \([0-9]*\)ms .*/\1/' | sort -h \
+        | datamash count 1 min 1 max 1 median 1 mean 1 perc 1 \
+                   -t ' '  --format="%10.1f" )
+    if [ -z "$res" ]; then
+        printf "%10.1f\n" 0
+    else
+        echo "$res"
+    fi
+}
+
+n_files=$#
+echo
+echo "Unreasonably long poll intervals:"
+echo
+echo "---------------------------------------------------------------------"
+echo "     Count      Min        Max       Median      Mean   95 percentile"
+echo "---------------------------------------------------------------------"
+
+for file in "$@"; do
+    mine_data_for_poll_intervals "$(cat $file)"
+done
+
+if test ${n_files} -gt 1; then
+    echo "---------------------------------------------------------------------"
+    mine_data_for_poll_intervals "$(cat $@)"
+fi
+echo


### PR DESCRIPTION
This commit adds a couple of scripts that mines data about unreasonably
long poll intervals from logs and stores it in a human-readable format
with all the statistics including min, max, avg, 95 percentile, etc.
values per OVN daemon.  For databases it tries to exclude poll
intervals that involved compactions and also collects data about time
spent on compactions separately.  Logic for this is not ideal, but it
seems to work fine for most cases.

Statistics counted with 'datamash' utility which is a new dependency.

Example of the output:
```
  Unreasonably long poll intervals:

  ---------------------------------------------------------------------
      Count       Min        Max       Median      Mean   95 percentile
  ---------------------------------------------------------------------
      1073.0     1000.0     9341.0     1612.0     3483.7     8401.2
      2031.0     1011.0     9961.0     1544.0     2533.1     8157.0
      3332.0     1000.0     9501.0     1467.5     2698.3     8293.0
  ---------------------------------------------------------------------
      6436.0     1000.0     9961.0     1565.5     2777.1     8302.2
```

Here is a result per log file and the result when all log files
considered all together, i.e. 'Mean' on the last line is not an average
of 'Mean' values of all rows, but a 'Mean' value of the data from all
the files.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>