### PR TITLE
ovn-tester: Use logging module instead of plain prints.

### DIFF
--- a/ovn-tester/ovn_context.py
+++ b/ovn-tester/ovn_context.py
@@ -1,5 +1,8 @@
+import logging
 import ovn_stats
 import time
+
+log = logging.getLogger(__name__)
 
 active_context = None
 
@@ -20,14 +23,14 @@ class Context(object):
 
     def __enter__(self):
         global active_context
-        print(f'***** Entering context {self.test_name} *****')
+        log.info(f'Entering context {self.test_name}')
         ovn_stats.clear()
         active_context = self
         return self
 
     def __exit__(self, type, value, traceback):
         ovn_stats.report(self.test_name, brief=self.brief_report)
-        print(f'***** Exiting context {self.test_name} *****')
+        log.info(f'Exiting context {self.test_name}')
 
     def __iter__(self):
         return self
@@ -37,9 +40,9 @@ class Context(object):
         if self.iteration_start:
             duration = now - self.iteration_start
             ovn_stats.add(ITERATION_STAT_NAME, duration, failed=self.failed)
-            print(f'***** Context {self.test_name}, '
-                  f'Iteration {self.iteration}, '
-                  f'Result: {"FAILURE" if self.failed else "SUCCESS"} *****')
+            log.log(logging.WARNING if self.failed else logging.INFO,
+                    f'Context {self.test_name}, Iteration {self.iteration}, '
+                    f'Result: {"FAILURE" if self.failed else "SUCCESS"}')
         self.failed = False
         if self.test:
             # exec external cmd
@@ -47,8 +50,7 @@ class Context(object):
         self.iteration_start = now
         if self.iteration < self.max_iterations - 1:
             self.iteration += 1
-            print(f'***** Context {self.test_name}, '
-                  f'Iteration {self.iteration} *****')
+            log.info(f'Context {self.test_name}, Iteration {self.iteration}')
             return self.iteration
         raise StopIteration
 

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import logging
 import sys
 import netaddr
 import yaml
@@ -10,6 +11,9 @@ from ovn_context import Context
 from ovn_sandbox import PhysicalNode
 from ovn_workload import BrExConfig, ClusterConfig
 from ovn_workload import CentralNode, WorkerNode, Cluster
+
+FORMAT = '%(asctime)s | %(name)-12s |%(levelname)s| %(message)s'
+logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
 
 DEFAULT_VIP_SUBNET = netaddr.IPNetwork('4.0.0.0/8')
 DEFAULT_N_VIPS = 2

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -1,5 +1,8 @@
+import logging
 from collections import namedtuple
 from io import StringIO
+
+log = logging.getLogger(__name__)
 
 LRouter = namedtuple('LRouter', ['name'])
 LRPort = namedtuple('LRPort', ['name'])
@@ -69,7 +72,7 @@ class OvnNbctl:
         self.run(f'set Connection . inactivity_probe={value}')
 
     def lr_add(self, name):
-        print(f'***** creating lrouter {name} *****')
+        log.info(f'Creating lrouter {name}')
         self.run(cmd=f'lr-add {name}')
         return LRouter(name=name)
 
@@ -78,11 +81,11 @@ class OvnNbctl:
         return LRPort(name=name)
 
     def lr_port_set_gw_chassis(self, rp, chassis, priority=10):
-        print(f'** Setting gw chassis {chassis} for router port {rp.name} **')
+        log.info(f'Setting gw chassis {chassis} for router port {rp.name}')
         self.run(cmd=f'lrp-set-gateway-chassis {rp.name} {chassis} {priority}')
 
     def ls_add(self, name, cidr):
-        print(f'***** creating lswitch {name} *****')
+        log.info(f'Creating lswitch {name}')
         self.run(cmd=f'ls-add {name}')
         return LSwitch(name=name, cidr=cidr)
 


### PR DESCRIPTION
'logging' module prints much more information including timestamps
which are useful while trying to match ovn-heater events with logs
from OVN daemons.

Multiline outputs from the sandbox execution are prefixed with "---\n",
because these doesn't look good when the first line is printed with all
the logging prefixes and the next ones are not.

Also, added a check that stderr is not empty to avoid printing blank
lines which are a bit annoying.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>

Some example:
```
2021-08-30 11:39:38,493 | ovn_context  |INFO| Context base_cluster_bringup, Iteration 1
2021-08-30 11:39:38,493 | ovn_workload |INFO| Connecting worker ovn-scale-1
2021-08-30 11:39:38,718 | ovn_sandbox  |INFO| ---
OVN remote = ssl:192.16.0.4:6642,ssl:192.16.0.5:6642,ssl:192.16.0.6:6642
Setting remote for ovn-scale-1
2021-08-30 11:39:38,854 | ovn_utils    |INFO| Creating lswitch lswitch-ovn-scale-1
2021-08-30 11:39:39,519 | ovn_utils    |INFO| Setting gw chassis ovn-scale-1 for router port rtr-to-node-ovn-scale-1
2021-08-30 11:39:39,658 | ovn_utils    |INFO| Creating lrouter gwrouter-ovn-scale-1
2021-08-30 11:39:40,413 | ovn_utils    |INFO| Creating lswitch ext-ovn-scale-1
2021-08-30 11:39:42,578 | ovn_workload |INFO| Creating lport lp-1-0
2021-08-30 11:39:42,901 | ovn_workload |INFO| Creating lport lp-1-1
2021-08-30 11:39:46,191 | ovn_workload |INFO| Pinging from lp-1-0 to 3.1.255.253
2021-08-30 11:39:46,334 | ovn_sandbox  |INFO| ---
PING 3.1.255.253 (3.1.255.253) 56(84) bytes of data.

--- 3.1.255.253 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 3.081/3.081/3.081/0.000 ms
2021-08-30 11:39:46,334 | ovn_workload |INFO| Pinging from lp-1-1 to 3.1.255.253
2021-08-30 11:39:46,469 | ovn_sandbox  |INFO| ---
PING 3.1.255.253 (3.1.255.253) 56(84) bytes of data.

--- 3.1.255.253 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 1.576/1.576/1.576/0.000 ms
2021-08-30 11:39:46,469 | ovn_context  |INFO| Context base_cluster_bringup, Iteration 1, Result: SUCCESS
```
