### PR TITLE
Fix per-ns load balancer support.

### DIFF
--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -362,6 +362,7 @@ class Namespace(object):
         self.sub_pg = []
         self.load_balancer = None
         self.cluster.n_ns += 1
+        self.name = name
 
     @ovn_stats.timeit
     def add_ports(self, ports):
@@ -520,8 +521,8 @@ class Namespace(object):
             worker = src.metadata
             worker.ping_port(self.cluster, src, dst.ip)
 
-    def create_load_balancer(self, lb_name):
-        self.load_balancer = lb.OvnLoadBalancer(lb_name, self.nbctl)
+    def create_load_balancer(self):
+        self.load_balancer = lb.OvnLoadBalancer(f'lb_{self.name}', self.nbctl)
 
     @ovn_stats.timeit
     def provision_vips_to_load_balancers(self, backend_lists):
@@ -638,3 +639,4 @@ class Cluster(object):
     def provision_lb(self, lb):
         for w in self.worker_nodes:
             lb.add_to_switch(w.switch.name)
+            lb.add_to_router(w.gw_router.name)

--- a/ovn-tester/tests/cluster_density.py
+++ b/ovn-tester/tests/cluster_density.py
@@ -37,34 +37,24 @@ class ClusterDensity(ExtCmd):
             ports = ovn.provision_ports(DENSITY_N_PODS * self.config.n_startup,
                                         passive=True)
             for i in range(self.config.n_startup):
-                ns = Namespace(ovn, f'NS_{i}')
+                ns = Namespace(ovn, f'NS_density_{i}')
                 ns.add_ports(
                     ports[DENSITY_N_PODS * i:DENSITY_N_PODS * (i + 1)]
                 )
+                ns.create_load_balancer()
+                ovn.provision_lb(ns.load_balancer)
+                ns.provision_vips_to_load_balancers(
+                            [ports[i * DENSITY_N_PODS:i * DENSITY_N_PODS + 2],
+                             [ports[i * DENSITY_N_PODS + 2]],
+                             [ports[i * DENSITY_N_PODS + 3]]])
                 all_ns.append(ns)
-
-            backends = []
-            backends.extend([
-                ports[i * DENSITY_N_PODS:i * DENSITY_N_PODS + 1]
-                for i in range(self.config.n_startup)
-            ])
-            backends.extend([
-                [ports[i * DENSITY_N_PODS + 2]]
-                for i in range(self.config.n_startup)
-            ])
-            backends.extend([
-                [ports[i * DENSITY_N_PODS + 3]]
-                for i in range(self.config.n_startup)
-            ])
-            ovn.provision_vips_to_load_balancers(backends)
 
         with Context('cluster_density',
                      (self.config.n_runs - self.config.n_startup) //
                      self.batch_ratio, test=self) as ctx:
             for i in ctx:
-                ns = Namespace(ovn, 'NS_{}'.format(self.config.n_startup + i))
-                ns.create_load_balancer(
-                        'lb_NS_{}'.format(self.config.n_startup + i))
+                ns = Namespace(ovn, f'NS_density_{self.config.n_startup + i}')
+                ns.create_load_balancer()
                 ovn.provision_lb(ns.load_balancer)
                 all_ns.append(ns)
 
@@ -81,7 +71,7 @@ class ClusterDensity(ExtCmd):
                             j*DENSITY_N_TOT_PODS+DENSITY_N_BUILD_PODS:
                             (j+1)*DENSITY_N_TOT_PODS]
                     ns.add_ports(ports)
-                    # add VIPs and backends to cluster load-balancer
+                    # add VIPs and backends to namespace load-balancer
                     ns.provision_vips_to_load_balancers(
                             [ports[0:2], ports[2:3], ports[3:4]])
 

--- a/ovn-tester/tests/density_heavy.py
+++ b/ovn-tester/tests/density_heavy.py
@@ -40,7 +40,7 @@ class DensityHeavy(ExtCmd):
             return
 
         ns = Namespace(ovn, 'ns_density_heavy')
-        ns.create_load_balancer('lb_density_heavy')
+        ns.create_load_balancer()
         ovn.provision_lb(ns.load_balancer)
 
         with Context('density_heavy_startup', brief_report=True) as ctx:


### PR DESCRIPTION
For cluster density tests, the code didn't provision a load balancer per
ns during the startup stage.

Also, per namespace load balancers were not added to gw routers.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>