### PR TITLE
Batch load_balancer bind to switch/router operations.

### DIFF
--- a/ovn-tester/ovn_load_balancer.py
+++ b/ovn-tester/ovn_load_balancer.py
@@ -76,18 +76,18 @@ class OvnLoadBalancer(object):
         for lb in self.lbs:
             self.nbctl.lb_set_vips(lb.uuid, self.vips)
 
-    def add_to_router(self, router):
+    def add_to_routers(self, routers):
         for lb in self.lbs:
-            self.nbctl.lb_add_to_router(lb.uuid, router)
+            self.nbctl.lb_add_to_routers(lb.uuid, routers)
 
-    def add_to_switch(self, switch):
+    def add_to_switches(self, switches):
         for lb in self.lbs:
-            self.nbctl.lb_add_to_switch(lb.uuid, switch)
+            self.nbctl.lb_add_to_switches(lb.uuid, switches)
 
-    def remove_from_router(self, router):
+    def remove_from_routers(self, routers):
         for lb in self.lbs:
-            self.nbctl.lb_remove_from_router(lb.uuid, router)
+            self.nbctl.lb_remove_from_routers(lb.uuid, routers)
 
-    def remove_from_switch(self, switch):
+    def remove_from_switches(self, switches):
         for lb in self.lbs:
-            self.nbctl.lb_remove_from_switch(lb.uuid, switch)
+            self.nbctl.lb_remove_from_switches(lb.uuid, switches)

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -200,20 +200,20 @@ class OvnNbctl:
     def lb_clear_vips(self, lb_uuid):
         self.run(cmd=f'clear Load_Balancer {lb_uuid} vips')
 
-    def lb_add_to_router(self, lb_uuid, router):
-        cmd = f"lr-lb-add {router} {lb_uuid}"
+    def lb_add_to_routers(self, lb_uuid, routers):
+        cmd = ' -- '.join([f'lr-lb-add {r} {lb_uuid}' for r in routers])
         self.run(cmd=cmd)
 
-    def lb_add_to_switch(self, lb_uuid, switch):
-        cmd = f"ls-lb-add {switch} {lb_uuid}"
+    def lb_add_to_switches(self, lb_uuid, switches):
+        cmd = ' -- '.join([f'ls-lb-add {s} {lb_uuid}' for s in switches])
         self.run(cmd=cmd)
 
-    def lb_remove_from_router(self, lb_uuid, router):
-        cmd = f"lr-lb-del {router} {lb_uuid}"
+    def lb_remove_from_routers(self, lb_uuid, routers):
+        cmd = ' -- '.join([f'lr-lb-del {r} {lb_uuid}' for r in routers])
         self.run(cmd=cmd)
 
-    def lb_remove_from_switch(self, lb_uuid, switch):
-        cmd = f"ls-lb-del {switch} {lb_uuid}"
+    def lb_remove_from_switches(self, lb_uuid, switches):
+        cmd = ' -- '.join([f'ls-lb-del {s} {lb_uuid}' for s in switches])
         self.run(cmd=cmd)
 
     def wait_until(self, cmd=""):

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -276,15 +276,15 @@ class WorkerNode(Node):
         cluster_vips = cluster.cluster_cfg.vips.keys()
         cluster.load_balancer.add_backends_to_vip(port_ips,
                                                   cluster_vips)
-        cluster.load_balancer.add_to_switch(self.switch.name)
-        cluster.load_balancer.add_to_router(self.gw_router.name)
+        cluster.load_balancer.add_to_switches([self.switch.name])
+        cluster.load_balancer.add_to_routers([self.gw_router.name])
 
         # GW Load balancer has no VIPs/backends configured on it, since
         # this load balancer is used for hostnetwork services. We're not
         # using those right now so the load blaancer is empty.
         self.gw_load_balancer = lb.OvnLoadBalancer(
             f'lb-{self.gw_router.name}', cluster.nbctl)
-        self.gw_load_balancer.add_to_router(self.gw_router.name)
+        self.gw_load_balancer.add_to_routers([self.gw_router.name])
 
     @ovn_stats.timeit
     def bind_port(self, port):
@@ -637,6 +637,5 @@ class Cluster(object):
         return self.worker_nodes[self.last_selected_worker]
 
     def provision_lb(self, lb):
-        for w in self.worker_nodes:
-            lb.add_to_switch(w.switch.name)
-            lb.add_to_router(w.gw_router.name)
+        lb.add_to_switches([w.switch.name for w in self.worker_nodes])
+        lb.add_to_routers([w.gw_router.name for w in self.worker_nodes])


### PR DESCRIPTION
On scaled setups, since we moved to load balancer per namespace there
will be lots of load balancers that need to be bound to lots of node
gateway routers/switches.  Binding to one node at a time is just a waste
of time.  Change load balancer APIs to allow binding to multiple
routers/switches in one operation.

For example, on a 20 node cluster density test run (10 startup
iterations) this reduces the test runtime by ~4 minutes (~40%).

Signed-off-by: Dumitru Ceara <dceara@redhat.com>