### PR TITLE
ovn-tester: Don't try creating the veth twice.

### DIFF
--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -140,7 +140,6 @@ class WorkerNode(Node):
         host_ip = netaddr.IPAddress(self.ext_net.last - 2)
 
         self.run(cmd='ip link add veth0 type veth peer name veth1')
-        self.run(cmd='ip link add veth0 type veth peer name veth1')
         self.run(cmd='ip netns add ext-ns')
         self.run(cmd='ip link set netns ext-ns dev veth0')
         self.run(cmd='ip netns exec ext-ns ip link set dev veth0 up')


### PR DESCRIPTION
For some reason the exact same veth creation command is run twice in a
row when provisioning. Adding some debugging, I saw the following:

2021-09-01 14:06:15,391 | ovn_sandbox  |WARNING| Command docker exec ovn-scale-1 ip link add veth0 type veth peer name veth1 exited with status 2
2021-09-01 14:06:15,391 | ovn_sandbox  |WARNING| stderr: RTNETLINK answers: File exists

The error is benign, but we may as well get rid of it.