### PR TITLE
ovn-tester: Separate relays from other DBs.

### DIFF
--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -193,9 +193,10 @@ def create_nodes(cluster_config, central, workers):
     ] if cluster_config.clustered_db else [
         'ovn-central'
     ]
-    for i in range(cluster_config.n_relays):
-        db_containers.append(f'ovn-relay-{i + 1}')
-    central_node = CentralNode(central, db_containers, mgmt_net, mgmt_ip)
+    relay_containers = [f'ovn-relay-{i + 1}' for i in
+                        range(cluster_config.n_relays)]
+    central_node = CentralNode(central, db_containers, relay_containers,
+                               mgmt_net, mgmt_ip)
     worker_nodes = [
         WorkerNode(workers[i % len(workers)], f'ovn-scale-{i}',
                    mgmt_net, mgmt_ip + i + 1, internal_net.next(i),

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -68,10 +68,12 @@ class Node(ovn_sandbox.Sandbox):
 
 
 class CentralNode(Node):
-    def __init__(self, phys_node, db_containers, mgmt_net, mgmt_ip):
+    def __init__(self, phys_node, db_containers, relay_containers, mgmt_net,
+                 mgmt_ip):
         super(CentralNode, self).__init__(phys_node, db_containers[0],
                                           mgmt_net, mgmt_ip)
         self.db_containers = db_containers
+        self.relay_containers = relay_containers
 
     def start(self, cluster_cfg):
         log.info('Starting central node')
@@ -97,6 +99,10 @@ class CentralNode(Node):
                                f'/run/ovn/ovnnb_db.ctl '
                                f'ovsdb-server/memory-trim-on-compaction on')
             self.phys_node.run(f'docker exec {db_container} ovs-appctl -t '
+                               f'/run/ovn/ovnsb_db.ctl '
+                               f'ovsdb-server/memory-trim-on-compaction on')
+        for relay_container in self.relay_containers:
+            self.phys_node.run(f'docker exec {relay_container} ovs-appctl -t '
                                f'/run/ovn/ovnsb_db.ctl '
                                f'ovsdb-server/memory-trim-on-compaction on')
 


### PR DESCRIPTION
relay containers only run a southbound database. Therefore, when we try
to enable trim on compaction for the northbound database in that
container, it results in an error. The error is benign, but it still is
better not to issue a useless command.

This commit fixes the problem by separating relay containers from other
DB containers. This way, they can get special treatment if necessary. In
this particular case, the special treatment is not to try to configure a
non-existent database.

Signed-off-by: Mark Michelson <mmichels@redhat.com>