### PR TITLE
ovn-tester: Unprovision build_ports via the namespace.

### DIFF
--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -395,6 +395,15 @@ class Namespace(object):
         for addr_set in self.sub_as:
             self.nbctl.address_set_del(addr_set)
 
+    def unprovision_ports(self, ports):
+        '''Unprovision a subset of ports in the namespace without having to
+        unprovision the entire namespace or any of its network policies.'''
+
+        for port in ports:
+            self.ports.remove(port)
+
+        self.cluster.unprovision_ports(ports)
+
     def enforce(self):
         if self.enforcing:
             return

--- a/ovn-tester/tests/cluster_density.py
+++ b/ovn-tester/tests/cluster_density.py
@@ -76,7 +76,7 @@ class ClusterDensity(ExtCmd):
                             [ports[0:2], ports[2:3], ports[3:4]])
 
                     ovn.ping_ports(ports)
-                    ovn.unprovision_ports(build_ports)
+                    ns.unprovision_ports(build_ports)
 
         if not global_cfg.cleanup:
             return


### PR DESCRIPTION
In the cluster_density test, we create a list of build ports, followed
by other ports during an iteration. At the end of the iteration, we
unprovision the build ports.

If global configuration is set to clean up at the end of a test, we then
try to unprovision all ports in the namespace once the test completes.
The problem is, we already unprovisioned the build ports during each
iteration. The namespace doesn't know this, and it results in errors.

This commit adds a new method for Namespace to unprovision a subset of
ports. We now unprovision the build ports in the cluster_density test
using this method. Now when the test ends and the namespace is
unprovisioned, it only unprovisions the remaining ports.

Signed-off-by: Mark Michelson <mmichels@redhat.com>