### PR TITLE
ovn-tester: Ensure unique names for port groups and address sets.

### DIFF
--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -405,10 +405,11 @@ class Namespace(object):
 
     def create_sub_ns(self, ports):
         n_sub_pgs = len(self.sub_pg)
-        pg = self.nbctl.port_group_create(f'sub_pg_{n_sub_pgs}')
+        suffix = f'{self.name}_{n_sub_pgs}'
+        pg = self.nbctl.port_group_create(f'sub_pg_{suffix}')
         self.nbctl.port_group_add_ports(pg, ports)
         self.sub_pg.append(pg)
-        addr_set = self.nbctl.address_set_create(f'sub_as_{n_sub_pgs}')
+        addr_set = self.nbctl.address_set_create(f'sub_as_{suffix}')
         self.nbctl.address_set_add_addrs(addr_set,
                                          [str(p.ip) for p in ports])
         self.sub_as.append(addr_set)

--- a/ovn-tester/tests/netpol.py
+++ b/ovn-tester/tests/netpol.py
@@ -38,7 +38,7 @@ class NetPol(ExtCmd):
                         i % self.config.n_labels, []).append(self.ports[i])
 
             for i in range(self.config.n_ns):
-                ns = Namespace(ovn, f'NS_{i}')
+                ns = Namespace(ovn, f'NS_{self.name}_{i}')
                 ns.add_ports(
                         self.ports[i * self.config.pods_ns_ratio:
                                    (i + 1)*self.config.pods_ns_ratio])

--- a/ovn-tester/tests/netpol_cross_ns.py
+++ b/ovn-tester/tests/netpol_cross_ns.py
@@ -25,7 +25,7 @@ class NetpolCrossNs(ExtCmd):
             ports = ovn.provision_ports(
                     self.config.pods_ns_ratio*self.config.n_ns)
             for i in range(self.config.n_ns):
-                ns = Namespace(ovn, f'NS_{i}')
+                ns = Namespace(ovn, f'NS_netpol_cross_ns_startup_{i}')
                 ns.add_ports(ports[i*self.config.pods_ns_ratio:
                                    (i + 1) * self.config.pods_ns_ratio])
                 ns.default_deny()

--- a/ovn-tester/tests/netpol_multitenant.py
+++ b/ovn-tester/tests/netpol_multitenant.py
@@ -79,7 +79,7 @@ class NetpolMultitenant(ExtCmd):
                 # includes i.
                 ranges = self.config.ranges
                 n_ports = next((r.n_pods for r in ranges if i >= r.start), 1)
-                ns = Namespace(ovn, f'ns_{i}')
+                ns = Namespace(ovn, f'ns_netpol_multitenant_{i}')
                 for _ in range(n_ports):
                     worker = ovn.select_worker_for_port()
                     for p in worker.provision_ports(ovn, 1):


### PR DESCRIPTION
There are two issues addressed here.

First, sub-namespaces base the name on the number of port groups created
in a given namespace. This means that if multiple namespaces are
created, then each of those namespaces attempts to create port groups
and address sets with the same names. This results in transaction
errors, meaning the port groups and address sets are not created. This
is fixed in this commit by having the port groups and address sets also
include the namespace name.

Second, if cleanup is not enabled for tests, then subsequent tests would
create namespaces with identical names. This results in the same
transaction errors. This is fixed in this commit by ensuring all network
policy tests create uniquely named namespaces.

Signed-off-by: Mark Michelson <mmichels@redhat.com>