### PR TITLE
Change the default OVN_FAKE_MULTINODE_BRANCH value to 'main'

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -153,7 +153,7 @@ ovn_branch="${OVN_BRANCH:-main}"
 
 # ovn-fake-multinode env vars
 ovn_fmn_repo="${OVN_FAKE_MULTINODE_REPO:-https://github.com/ovn-org/ovn-fake-multinode.git}"
-ovn_fmn_branch="${OVN_FAKE_MULTINODE_BRANCH:-master}"
+ovn_fmn_branch="${OVN_FAKE_MULTINODE_BRANCH:-main}"
 
 OS_IMAGE_OVERRIDE="${OS_IMAGE_OVERRIDE}"
 


### PR DESCRIPTION
'master' branch of ovn-fake-multinode is renamed to 'main'.

Signed-off-by: Numan Siddique <nusiddiq@redhat.com>