### PR TITLE
test-scenarios: Lower target for 120 node density heavy.

### DIFF
--- a/test-scenarios/ocp-120-density-heavy.yml
+++ b/test-scenarios/ocp-120-density-heavy.yml
@@ -10,5 +10,5 @@ base_cluster_bringup:
   n_pods_per_node: 10
 
 density_heavy:
-  n_startup: 30000
-  n_pods: 31250
+  n_startup: 10000
+  n_pods: 10250


### PR DESCRIPTION
Since moving to load balancer per iteration this takes takes way too
long to execute completely.  Lower the targets to something that still
makes the test fail (so we can observe future performance improvements)
but takes a more reasonable time to complete.

Signed-off-by: Dumitru Ceara <dceara@redhat.com>