### PR TITLE
ovn_workload: Log creation of load balancers.

### DIFF
--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -671,4 +671,5 @@ class Cluster(object):
             self.nbctl.lr_add_lbg(w.gw_router, self.lb_group.lbg)
 
     def provision_lb(self, lb):
+        log.info(f'Creating load balancer {lb.name}')
         self.lb_group.add_lb(lb)


### PR DESCRIPTION
ocp-120-density-heavy scenario creates 5000 load balancers
during the "startup" phase.  It takes 3-4 hours and there
are no logs printed during that time.

Fix that by actually logging creation of load balancers.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>