### PR TITLE
Collect RSS and CPU usage for OVS/OVN processes.

### DIFF
--- a/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
+++ b/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
@@ -47,3 +47,9 @@
       src: "{{ rundir }}/perf.sh"
       dest: /tmp/perf.sh
       mode: '0744'
+
+  - name: Deploy process monitor script
+    copy:
+      src: "{{ rundir }}/process-monitor.py"
+      dest: /tmp/process-monitor.py
+      mode: '0744'

--- a/ovn-fake-multinode-utils/process-monitor.py
+++ b/ovn-fake-multinode-utils/process-monitor.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import psutil
+import time
+
+
+process_names = ['ovn-', 'ovs-', 'ovsdb-', 'etcd']
+
+def monitor(suffix, out_file, exit_file):
+    data = {}
+    while True:
+        try:
+            if os.path.exists(exit_file):
+                raise KeyboardInterrupt
+
+            processes = set()
+            for p in psutil.process_iter():
+                if any(name in p.name() for name in process_names):
+                    processes.add(p)
+
+            if len(processes) == 0:
+                time.sleep(0.5)
+                continue
+
+            tme = time.time()
+            for p in processes:
+                try:
+                    name = p.name() + "-" + suffix + "-" + str(p.pid)
+                    # cpu_percent(seconds) call will block
+                    # for the amount of seconds specified.
+                    cpu = p.cpu_percent(0.5)
+                    mem = p.memory_info().rss
+                except psutil.NoSuchProcess:
+                    # Process went away.  Skipping.
+                    continue
+
+                if not data.get(tme):
+                    data[tme] = {}
+
+                data[tme][name] = {'cpu': cpu, 'rss': mem}
+
+        except KeyboardInterrupt:
+            with open(out_file, "w") as f:
+                json.dump(data, f, indent=4, sort_keys=True)
+            break
+
+        except:
+            # Ignoring all unexpected exceptions to avoid loosing data.
+            continue
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='OVS/OVN process monitor')
+    parser.add_argument('-s', '--suffix',
+                        help='Process name suffix to add', default='')
+    parser.add_argument('-o', '--output', help='Output file name',
+                        default='process-stats.json')
+    parser.add_argument('-x', '--exit-file', help='File that signals to exit',
+                        default='process-monitor.exit')
+
+    args = parser.parse_args()
+    monitor(args.suffix, args.output, args.exit_file)

--- a/ovn-fake-multinode-utils/scripts/log-collector.sh
+++ b/ovn-fake-multinode-utils/scripts/log-collector.sh
@@ -8,10 +8,12 @@ pushd /tmp
 for c in $(docker ps --format "{{.Names}}" --filter "name=${node_name}"); do
     mkdir ${host}/$c
     docker exec $c ps -aux > ${host}/$c/ps
+    docker exec $c bash -c 'touch /tmp/process-monitor.exit && sleep 5'
     docker cp $c:/var/log/ovn/ovn-controller.log ${host}/$c/
     docker cp $c:/var/log/openvswitch/ovs-vswitchd.log ${host}/$c/
     docker cp $c:/var/log/openvswitch/ovsdb-server.log ${host}/$c/
     docker cp $c:/etc/openvswitch/conf.db ${host}/$c/
+    docker cp $c:/var/log/process-stats.json ${host}/$c/
 done
 
 for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-central"); do
@@ -20,6 +22,7 @@ for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-central"); do
     docker exec $c ovs-appctl --timeout=30 -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/compact
     docker exec $c ovs-appctl --timeout=30 -t /var/run/ovn/ovnnb_db.ctl ovsdb-server/compact
     docker exec $c ps -aux > ${host}/$c/ps-after-compaction
+    docker exec $c bash -c 'touch /tmp/process-monitor.exit && sleep 5'
     docker cp $c:/var/log/ovn/ovn-controller.log ${host}/$c/
     docker cp $c:/var/log/ovn/ovn-northd.log ${host}/$c/
     docker cp $c:/var/log/ovn/ovsdb-server-nb.log ${host}/$c/
@@ -29,6 +32,7 @@ for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-central"); do
     docker cp $c:/var/log/openvswitch/ovs-vswitchd.log ${host}/$c/
     docker cp $c:/var/log/openvswitch/ovsdb-server.log ${host}/$c/
     docker cp $c:/var/log/openvswitch/ovn-nbctl.log ${host}/$c/
+    docker cp $c:/var/log/process-stats.json ${host}/$c/
 done
 
 for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-relay"); do
@@ -36,7 +40,9 @@ for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-relay"); do
     docker exec $c ps -aux > ${host}/$c/ps-before-compaction
     docker exec $c ovs-appctl --timeout=30 -t /var/run/ovn/ovnsb_db.ctl ovsdb-server/compact
     docker exec $c ps -aux > ${host}/$c/ps-after-compaction
+    docker exec $c bash -c 'touch /tmp/process-monitor.exit && sleep 5'
     docker cp $c:/var/log/ovn/ovsdb-server-sb.log ${host}/$c/
+    docker cp $c:/var/log/process-stats.json ${host}/$c/
 done
 
 journalctl --since "8 hours ago" -a > ${host}/messages

--- a/utils/process-stats.py
+++ b/utils/process-stats.py
@@ -1,0 +1,62 @@
+import json
+import numpy
+import os
+import pandas as pd
+import plotly.express as px
+import sys
+import time
+
+from datetime import datetime
+
+
+def read_file(filename):
+    with open(filename, "r") as file:
+        return json.load(file)
+
+def resource_stats_generate(filename, data):
+    rss = []
+    cpu = []
+
+    for ts, time_slice in sorted(data.items()):
+        for name, res in time_slice.items():
+            tme = datetime.fromtimestamp(float(ts))
+            rss_mb = int(res['rss']) >> 20
+            rss.append([tme, name, rss_mb])
+            cpu.append([tme, name, float(res['cpu'])])
+
+    df_rss = pd.DataFrame(rss, columns=['Time', 'Process', 'RSS (MB)'])
+    df_cpu = pd.DataFrame(cpu, columns=['Time', 'Process', 'CPU (%)'])
+
+    rss_chart = px.line(df_rss, x='Time', y='RSS (MB)', color='Process',
+                        title='Resident Set Size')
+    cpu_chart = px.line(df_cpu, x='Time', y='CPU (%)', color='Process',
+                        title='CPU usage')
+
+    with open(filename, 'w') as report_file:
+        report_file.write('<html>')
+        report_file.write(rss_chart.to_html(full_html=False,
+                                            include_plotlyjs='cdn',
+                                            default_width='90%',
+                                            default_height='90%'))
+        report_file.write(cpu_chart.to_html(full_html=False,
+                                            include_plotlyjs='cdn',
+                                            default_width='90%',
+                                            default_height='90%'))
+        report_file.write('</html>')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print(f'Usage: {sys.argv[0]} output-file input-file [input-file ...]')
+        sys.exit(1)
+
+    if os.path.isfile(sys.argv[1]):
+        print(f'Output file {sys.argv[1]} already exists')
+        sys.exit(2)
+
+    data = {}
+    for f in sys.argv[2:]:
+        d = read_file(f)
+        data.update(d)
+
+    resource_stats_generate(sys.argv[1], data)


### PR DESCRIPTION
With this change the new process-monitor.py script is copied into
each container and started to collect RSS and CPU usage of all
OVS/OVN processes.  Later, log-collector will stop the monitoring
and will collect results as a process-stats.json file.  do.sh
script then uses process-stats.py script at the data mining stage
to produce html reports for master and worker nodes containing
RSS an CPU usage graphs.

The integration part is a bit sketchy.  Alternative is to avoid
modification of the ovn-tester itself and only deploy the
process monitor on the physical host.  This will make the code
a bit cleaner, but we'll loose an easy way to add container names
to process names.  Also, the monitor spends 0.5 seconds per process
to estimate the CPU usage.  More processes to track - less accurate
the results.  For example, one round of measurements for 9 processes
takes ~4.5 seconds, so we can easily miss the 3 second database
compaction.  We could run a monitor per process though, but that
sounds like an overkill.

In order to work properly, python3-psutil needs to be installed
in the container.  If it's not available, ovn-heater will still
work normally, but resource usage reports will not be generated.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>