### PR TITLE
do.sh: Gracefully deal with grep pipefail when processing stats.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -319,7 +319,7 @@ function run_test() {
 
     # Collecting stats only for 3 workers to avoid bloating the report.
     resource_usage_logs=$(find ${out_dir}/logs -name process-stats.json \
-                            | grep ovn-scale | head -3)
+                            | (grep ovn-scale || true) | head -3)
     python3 ${topdir}/utils/process-stats.py \
         resource-usage-report-worker.html ${resource_usage_logs}
 


### PR DESCRIPTION
The 'head -3' command might close the pipe while grep is still
writing to it, causing a SIGPIPE, which in turn causes the script to
fail because we run 'do.sh' with 'pipefail' set.