### PR TITLE
do.sh: Handle all expected pipe failures properly.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -319,7 +319,7 @@ function run_test() {
 
     # Collecting stats only for 3 workers to avoid bloating the report.
     resource_usage_logs=$(find ${out_dir}/logs -name process-stats.json \
-                            | (grep ovn-scale || true) | head -3)
+                            | grep ovn-scale | head -3 || true)
     python3 ${topdir}/utils/process-stats.py \
         resource-usage-report-worker.html ${resource_usage_logs}
 


### PR DESCRIPTION
Commit 8208181f1e33 ("do.sh: Gracefully deal with grep pipefail when processing
stats.") is incomplete in dealing with pipe failures because it only
took care of the first failure in the chain.  Properly deal with it by
adding 'or TRUE' at the end.