### PR TITLE
ovn-tester: Add 60 and 180 node OCP like test scenarios.

### DIFF
--- a/test-scenarios/ocp-180-cluster-density.yml
+++ b/test-scenarios/ocp-180-cluster-density.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 180
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+cluster_density:
+  n_startup: 2800
+  n_runs: 3000

--- a/test-scenarios/ocp-180-density-heavy.yml
+++ b/test-scenarios/ocp-180-density-heavy.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 180
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+density_heavy:
+  n_startup: 7850
+  n_pods: 8100

--- a/test-scenarios/ocp-180-density-light.yml
+++ b/test-scenarios/ocp-180-density-light.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 180
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+density_light:
+  n_startup: 42850
+  n_pods: 44100

--- a/test-scenarios/ocp-180-np-multitenant.yml
+++ b/test-scenarios/ocp-180-np-multitenant.yml
@@ -1,0 +1,23 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 180
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+netpol_multitenant:
+  n_namespaces: 500
+  ranges:
+    - r1:
+      start:   200
+      n_pods:  5
+    - r2:
+      start:   480
+      n_pods:  20
+    - r3:
+      start:   495
+      n_pods:  100

--- a/test-scenarios/ocp-60-cluster-density.yml
+++ b/test-scenarios/ocp-60-cluster-density.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 60
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+cluster_density:
+  n_startup: 300
+  n_runs: 500

--- a/test-scenarios/ocp-60-density-heavy.yml
+++ b/test-scenarios/ocp-60-density-heavy.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 60
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+density_heavy:
+  n_startup: 2450
+  n_pods: 2700

--- a/test-scenarios/ocp-60-density-light.yml
+++ b/test-scenarios/ocp-60-density-light.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 60
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+density_light:
+  n_startup: 13450
+  n_pods: 14700

--- a/test-scenarios/ocp-60-np-multitenant.yml
+++ b/test-scenarios/ocp-60-np-multitenant.yml
@@ -1,0 +1,23 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 60
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+netpol_multitenant:
+  n_namespaces: 500
+  ranges:
+    - r1:
+      start:   200
+      n_pods:  5
+    - r2:
+      start:   480
+      n_pods:  20
+    - r3:
+      start:   495
+      n_pods:  100


### PR DESCRIPTION
Running tests at 20, 60, 120, 180, 250 node scales should help detect
whether OVN performance scales linearly or not.