### PR TITLE
ovn_workload: Log binding of a logical port.

### DIFF
--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -309,6 +309,7 @@ class WorkerNode(Node):
 
     @ovn_stats.timeit
     def bind_port(self, port):
+        log.info(f'Binding lport {port.name} on {self.container}')
         vsctl = ovn_utils.OvsVsctl(self)
         vsctl.add_port(port, 'br-int', internal=True, ifaceid=port.name)
         # Skip creating a netns for "passive" ports, we won't be sending


### PR DESCRIPTION
Binding is one of the most heavy operations and it's not logged at the
moment.  We may not see any logs for a log time while ovn-heater is
binding thousands of ports during the test startup stage, for example.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>