### PR TITLE
do.sh: Fix initial installation.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -64,8 +64,8 @@ function install_deps() {
         --skip-broken -y
     [ -e /usr/bin/pip ] || ln -sf /usr/bin/pip3 /usr/bin/pip
 
-    containers=$(docker ps --filter='name=(ovn|registry)' \
-                        | grep -v "CONTAINER ID" | awk '{print $1}')
+    containers=$(docker ps --all --filter='name=(ovn|registry)' \
+                        | grep -v "CONTAINER ID" | awk '{print $1}' || true)
     for container_name in $containers
     do
         docker stop $container_name
@@ -197,6 +197,8 @@ function install_ovn_fake_multinode() {
         [ -n "$RPM_OVN_CENTRAL" ] && wget $RPM_OVN_CENTRAL
         [ -n "$RPM_OVN_HOST" ] && wget $RPM_OVN_HOST
     fi
+
+    docker images | grep -q 'ovn/ovn-multi-node' || rebuild_needed=1
 
     if [ ${rebuild_needed} -eq 1 ]; then
         if [ -z "${OS_IMAGE_OVERRIDE}" ]; then


### PR DESCRIPTION
If there are no ovn/registry containers on a system, lookup will fail
and the 'pipefail' will fail the entire run.

If the registry container is stopped, it won't show up in the output
of a normal 'docker ps', but the subsequent 'docker run' will fail
to start container with the same name, so '--all' has to be used.

Also, if due to earlier failures everything is already checked out,
but the image doesn't exist, it will not be built.  So, we need to
check if the image is available and re-build if it is not.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>