### PR TITLE
do.sh: Add lport binding to ovn-installed latency to mined data.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -312,6 +312,19 @@ function run_test() {
         ${topdir}/utils/mine-db-poll-intervals.sh ${logs} > mined-data/${p}
     done
 
+    cat ${out_dir}/test-log | grep 'Binding lport' \
+        | cut -d ' ' -f 1,2,8 > mined-data/ovn-binding.log
+
+    logs=$(find ${out_dir}/logs -name ovn-controller.log)
+    grep ovn-installed ${logs} | cut -d ':' -f 2- | tr '|' ' ' \
+        | cut -d ' ' -f 1,7 | tr 'T' ' ' | sort > mined-data/ovn-installed.log
+
+    python3 ${topdir}/utils/latency.py "$(date +%z)" \
+        ./mined-data/ovn-binding.log ./mined-data/ovn-installed.log \
+        > mined-data/binding-to-ovn-installed-latency
+
+    rm -rf ./mined-data/ovn-binding.log ./mined-data/ovn-installed.log
+
     resource_usage_logs=$(find ${out_dir}/logs -name process-stats.json \
                             | grep -v ovn-scale)
     python3 ${topdir}/utils/process-stats.py \

--- a/utils/latency.py
+++ b/utils/latency.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from datetime import timedelta
+import numpy as np
+import sys
+
+if len(sys.argv) < 4:
+    print(f'Usage {sys.argv[0]} "$(date +%z)" '
+          f'ovn-binding.log ovn-installed.log')
+
+tz = -int(sys.argv[1])
+delta = timedelta(hours=int(tz / 100), minutes=int(tz % 100))
+
+with open(sys.argv[3], 'r') as installed_file:
+    ovn_installed = installed_file.read().strip().splitlines()
+
+with open(sys.argv[2], 'r') as binding_file:
+    ovn_binding = binding_file.read().strip().splitlines()
+
+latency_per_port = {}
+
+for record in ovn_binding:
+    record = record.split(' ')
+
+    date = record[0]
+    time = record[1]
+    port = record[2]
+
+    date = datetime.strptime(f'{date} {time}', '%Y-%m-%d %H:%M:%S,%f')
+    latency_per_port[port] = date + delta
+
+for record in ovn_installed:
+    record = record.split(' ')
+
+    date = record[0]
+    time = record[1]
+    port = record[2]
+
+    if isinstance(latency_per_port[port], timedelta):
+        # ovn-installed more than once, ignoring.
+        continue
+
+    date = datetime.strptime(f'{date} {time}', '%Y-%m-%d %H:%M:%S.%fZ')
+    latency_per_port[port] = date - latency_per_port[port]
+
+failures = 0
+latencies = []
+
+for port, latency in latency_per_port.items():
+    if isinstance(latency, datetime):
+        failures = failures + 1
+        continue
+    ms = int(latency.total_seconds() * 1000)
+    latencies.append(ms)
+
+print('''
+Latency between logical port binding, i.e. creation of the corresponding
+OVS port on the worker node, and ovn-controller setting up ovn-installed
+flag for that port according to test-log and ovn-controller logs.
+
+Note:
+This data can not be directly interpreted as OVN end-to-end latency,
+because port bindings are always happening after logical ports were already
+created in Northbound database.  And for bulk creations, bindings performed
+also in bulk after all creations are done.
+
+Look for 'Not installed' below to find for which ports ovn-installed was
+never set (at least, there is no evidence in logs).
+''')
+
+print('min     :', min(latencies), 'ms')
+print('max     :', max(latencies), 'ms')
+print('avg     :', int(sum(latencies) / len(latencies)), 'ms')
+print('95%     :', int(np.percentile(latencies, 95)), 'ms')
+print('total   :', len(latency_per_port))
+print('failures:', failures)
+print()
+
+for port, latency in latency_per_port.items():
+    if isinstance(latency, datetime):
+        print(f'{port:<10}: Not installed')
+        continue
+    ms = int(latency.total_seconds() * 1000)
+    print(f'{port:<10}: {ms}')


### PR DESCRIPTION
Difference per logical port between port being bound to the node
and ovn-controller marking it as ovn-installed, including usual
min, max, avg, 95%ile.  Ports that was never actually installed
are also counted.

Results are in the mined-data/binding-to-ovn-installed-latency.

The metric should be taken with a grain of salt, because ports
are bound (OVS port with iface-id created) after they were already
created in Nb DB.  And for bulk port creations, binding happens
in bulk as well afterward.  The value can be more or less treated
as an end to end OVN latency for ports created during the test
phase though.

Useful to spot issues like very high latency or ports not being
installed at all.

ovn-heater might be changed in the future to always bind ports
right after creation to make the metric more useful.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>