### PR TITLE
sandbox: Speed up command execution by re-using docker exec shell.

### DIFF
--- a/ovn-tester/ovn_sandbox.py
+++ b/ovn-tester/ovn_sandbox.py
@@ -1,6 +1,8 @@
 import logging
 import paramiko
+import socket
 
+from io import StringIO
 from ovn_exceptions import SSHError
 
 log = logging.getLogger(__name__)
@@ -58,9 +60,76 @@ class Sandbox(object):
     def __init__(self, phys_node, container):
         self.phys_node = phys_node
         self.container = container
+        self.channel = None
+
+    def ensure_channel(self):
+        if self.channel:
+            return
+
+        self.channel = self.phys_node.ssh.ssh.invoke_shell(width=10000,
+                                                           height=10000)
+        # Fail if command didn't finish after 1 minute.
+        self.channel.settimeout(60.0)
+        if self.container:
+            dcmd = 'docker exec -it ' + self.container + ' bash'
+            self.channel.sendall(f"{dcmd}\n".encode())
+
+        stdout = StringIO()
+        # Checking + consuming all the unwanted output from the shell.
+        self.run(cmd="echo Hello", stdout=stdout, raise_on_error=True)
 
     def run(self, cmd="", stdout=None, raise_on_error=False):
-        if self.container:
-            cmd = 'docker exec ' + self.container + ' ' + cmd
-        self.phys_node.run(cmd=cmd, stdout=stdout,
-                           raise_on_error=raise_on_error)
+        if self.phys_node.ssh.cmd_log:
+            log.info(f'Logging command: ssh {self.container} "{cmd}"')
+
+        self.ensure_channel()
+
+        # Can't have ';' right after '&'.
+        if not cmd.endswith('&'):
+            cmd = cmd + ' ;'
+
+        self.channel.sendall(f"echo '++++start'; "
+                             f"{cmd} echo $? ; "
+                             f"echo '++++end' \n".encode())
+        timed_out = False
+        out = ''
+        try:
+            out = self.channel.recv(10240).decode()
+            while '++++end' not in out.splitlines():
+                out = out + self.channel.recv(10240).decode()
+        except (paramiko.buffered_pipe.PipeTimeout, socket.timeout):
+            if '++++start' not in out.splitlines():
+                out = '++++start\n' + out
+            out = out + '\n42\n++++end'
+            timed_out = True
+            log.warning(f'Command "{cmd}" timed out!')
+            # Can't trust this shell anymore.
+            self.channel.close()
+            self.channel = None
+            pass
+
+        # Splitting and removing all lines with terminal control chars.
+        out = out.splitlines()
+        start = out.index('++++start') + 1
+        end = out.index('++++end') - 1
+        exit_status = int(out[end])
+        out = [s for s in out[start:end] if '\x1b' not in s]
+
+        if self.phys_node.ssh.cmd_log or timed_out:
+            log.info(f'Result: {out}, Exit status: {exit_status}')
+
+        out = '\n'.join(out).strip()
+
+        if exit_status != 0 and raise_on_error:
+            if len(out):
+                log.warning(SSH.printable_result(out))
+            raise SSHError(
+                f'Command "{cmd}" failed with exit_status {exit_status}.'
+            )
+
+        if stdout:
+            stdout.write(out)
+        else:
+            out = SSH.printable_result(out)
+            if len(out):
+                log.info(out)

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -103,6 +103,7 @@ class CentralNode(Node):
             self.run(cmd=f'ovs-appctl -t '
                      f'/run/ovn/ovnsb_db.ctl cluster/change-election-timer '
                      f'OVN_Southbound {timeout}')
+            time.sleep(1)
 
     def enable_trim_on_compaction(self):
         log.info('Setting DB trim-on-compaction')


### PR DESCRIPTION
Currently ovn-heater calls 'docker exec' via SSH connection to a
physical host every time it needs to execute any command inside
a container.  Just 'docker exec' itself adds anywhere from 150 to
500 ms of extra overhead to every call.

To avoid that overhead, creating a separate channel for each
container within a common SSH connection.  Using an interactive
shell emulator from the invoke_shell() method, invoking a docker
interactive shell.  Once this is done, we have a direct channel
to execute any commands inside of a container with only few
milliseconds of overhead (4-5 ms in practice).

Since it's not just a command execution API like paramiko's
exec_command(), but a real shell emulator, it's a bit trickier
to work with.  Shell sends back command prompts and everything
you send to it.  It also sends back lots of vt100 control/escape
symbols.  Command output is filtered out by adding special
start/end markers, the exit code is printed with echo and
parsed out as well.

There are no functional changes to tests, they are doing exactly
the same to what they were doing before, but with the command
execution being much faster.

One consequence of commands being executed faster is added sleep
to the election timer modifications that should wait for cluster
to agree on a new value before it can be changed again.

This change greatly improves the test speed.  For example, 250
node density heavy test can be finished in 1 hour and 20 minutes
instead of 9 hours before.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>