### PR TITLE
ovn-tester: Wait for all changes to be applied before exiting context.

### DIFF
--- a/ovn-tester/ovn_context.py
+++ b/ovn-tester/ovn_context.py
@@ -11,8 +11,8 @@ ITERATION_STAT_NAME = 'Iteration Total'
 
 
 class Context(object):
-    def __init__(self, test_name, max_iterations=1, brief_report=False,
-                 test=None):
+    def __init__(self, cluster, test_name, max_iterations=1,
+                 brief_report=False, test=None):
         self.iteration = -1
         self.test_name = test_name
         self.max_iterations = max_iterations
@@ -20,6 +20,7 @@ class Context(object):
         self.iteration_start = None
         self.failed = False
         self.test = test
+        self.cluster = cluster
 
     def __enter__(self):
         global active_context
@@ -29,6 +30,8 @@ class Context(object):
         return self
 
     def __exit__(self, type, value, traceback):
+        log.info('Waiting for the OVN state synchronization')
+        self.cluster.nbctl.run('--timeout=1800 --wait=hv sync')
         ovn_stats.report(self.test_name, brief=self.brief_report)
         log.info(f'Exiting context {self.test_name}')
 

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -208,14 +208,14 @@ def create_nodes(cluster_config, central, workers):
 
 def prepare_test(central_node, worker_nodes, cluster_cfg, brex_cfg):
     ovn = Cluster(central_node, worker_nodes, cluster_cfg, brex_cfg)
-    with Context("prepare_test"):
+    with Context(ovn, "prepare_test"):
         ovn.start()
     return ovn
 
 
 def run_base_cluster_bringup(ovn, bringup_cfg):
     # create ovn topology
-    with Context("base_cluster_bringup", len(ovn.worker_nodes)) as ctx:
+    with Context(ovn, "base_cluster_bringup", len(ovn.worker_nodes)) as ctx:
         ovn.create_cluster_router("lr-cluster")
         ovn.create_cluster_join_switch("ls-join")
         ovn.create_cluster_load_balancer("lb-cluster")

--- a/ovn-tester/tests/cluster_density.py
+++ b/ovn-tester/tests/cluster_density.py
@@ -32,7 +32,7 @@ class ClusterDensity(ExtCmd):
 
     def run(self, ovn, global_cfg):
         all_ns = []
-        with Context('cluster_density_startup', brief_report=True) as ctx:
+        with Context(ovn, 'cluster_density_startup', brief_report=True) as ctx:
             # create 4 legacy pods per iteration.
             ports = ovn.provision_ports(DENSITY_N_PODS * self.config.n_startup,
                                         passive=True)
@@ -49,7 +49,7 @@ class ClusterDensity(ExtCmd):
                              [ports[i * DENSITY_N_PODS + 3]]])
                 all_ns.append(ns)
 
-        with Context('cluster_density',
+        with Context(ovn, 'cluster_density',
                      (self.config.n_runs - self.config.n_startup) //
                      self.batch_ratio, test=self) as ctx:
             for i in ctx:
@@ -80,6 +80,6 @@ class ClusterDensity(ExtCmd):
 
         if not global_cfg.cleanup:
             return
-        with Context('cluster_density_cleanup', brief_report=True) as ctx:
+        with Context(ovn, 'cluster_density_cleanup', brief_report=True) as ctx:
             for ns in all_ns:
                 ns.unprovision()

--- a/ovn-tester/tests/density_heavy.py
+++ b/ovn-tester/tests/density_heavy.py
@@ -63,14 +63,14 @@ class DensityHeavy(ExtCmd):
 
         ns = Namespace(ovn, 'ns_density_heavy')
 
-        with Context('density_heavy_startup', brief_report=True) as ctx:
+        with Context(ovn, 'density_heavy_startup', brief_report=True) as ctx:
             ports = ovn.provision_ports(self.config.n_startup, passive=True)
             ns.add_ports(ports)
             for i in range(0, self.config.n_startup,
                            self.config.pods_vip_ratio):
                 self.create_lb(ovn, 'density_heavy_' + str(i), [[ports[i]]])
 
-        with Context('density_heavy',
+        with Context(ovn, 'density_heavy',
                      (self.config.n_pods - self.config.n_startup) /
                      self.config.batch, test=self) as ctx:
             for i in ctx:
@@ -85,6 +85,6 @@ class DensityHeavy(ExtCmd):
 
         if not global_cfg.cleanup:
             return
-        with Context('density_heavy_cleanup', brief_report=True) as ctx:
+        with Context(ovn, 'density_heavy_cleanup', brief_report=True) as ctx:
             ovn.unprovision_vips()
             ns.unprovision()

--- a/ovn-tester/tests/density_light.py
+++ b/ovn-tester/tests/density_light.py
@@ -23,12 +23,13 @@ class DensityLight(ExtCmd):
 
     def run(self, ovn, global_cfg):
         ns = Namespace(ovn, 'ns_density_light')
-        with Context('density_light_startup', 1, brief_report=True) as ctx:
+        with Context(ovn, 'density_light_startup', 1,
+                     brief_report=True) as ctx:
             ports = ovn.provision_ports(self.config.n_startup, passive=True)
             ns.add_ports(ports)
 
         n_iterations = self.config.n_pods - self.config.n_startup
-        with Context('density_light', n_iterations, test=self) as ctx:
+        with Context(ovn, 'density_light', n_iterations, test=self) as ctx:
             for i in ctx:
                 ports = ovn.provision_ports(1)
                 ns.add_ports(ports[0:1])
@@ -36,5 +37,5 @@ class DensityLight(ExtCmd):
 
         if not global_cfg.cleanup:
             return
-        with Context('density_light_cleanup', brief_report=True) as ctx:
+        with Context(ovn, 'density_light_cleanup', brief_report=True) as ctx:
             ns.unprovision()

--- a/ovn-tester/tests/netpol.py
+++ b/ovn-tester/tests/netpol.py
@@ -30,7 +30,7 @@ class NetPol(ExtCmd):
         self.ports = []
 
     def init(self, ovn):
-        with Context(f'{self.name}_startup', brief_report=True) as _:
+        with Context(ovn, f'{self.name}_startup', brief_report=True) as _:
             self.ports = ovn.provision_ports(
                     self.config.pods_ns_ratio*self.config.n_ns)
             for i in range(self.config.pods_ns_ratio*self.config.n_ns):
@@ -46,7 +46,7 @@ class NetPol(ExtCmd):
                 self.all_ns.append(ns)
 
     def run(self, ovn, global_cfg, exclude=False):
-        with Context(self.name, self.config.n_ns, test=self) as ctx:
+        with Context(ovn, self.name, self.config.n_ns, test=self) as ctx:
             for i in ctx:
                 ns = self.all_ns[i]
                 for lbl in range(self.config.n_labels):
@@ -67,6 +67,6 @@ class NetPol(ExtCmd):
 
         if not global_cfg.cleanup:
             return
-        with Context(f'{self.name}_cleanup', brief_report=True) as ctx:
+        with Context(ovn, f'{self.name}_cleanup', brief_report=True) as ctx:
             for ns in self.all_ns:
                 ns.unprovision()

--- a/ovn-tester/tests/netpol_cross_ns.py
+++ b/ovn-tester/tests/netpol_cross_ns.py
@@ -21,7 +21,7 @@ class NetpolCrossNs(ExtCmd):
     def run(self, ovn, global_cfg):
         all_ns = []
 
-        with Context('netpol_cross_ns_startup', brief_report=True) as ctx:
+        with Context(ovn, 'netpol_cross_ns_startup', brief_report=True) as ctx:
             ports = ovn.provision_ports(
                     self.config.pods_ns_ratio*self.config.n_ns)
             for i in range(self.config.n_ns):
@@ -31,7 +31,8 @@ class NetpolCrossNs(ExtCmd):
                 ns.default_deny()
                 all_ns.append(ns)
 
-        with Context('netpol_cross_ns', self.config.n_ns, test=self) as ctx:
+        with Context(ovn, 'netpol_cross_ns',
+                     self.config.n_ns, test=self) as ctx:
             for i in ctx:
                 ns = all_ns[i]
                 ext_ns = all_ns[(i+1) % self.config.n_ns]
@@ -40,6 +41,6 @@ class NetpolCrossNs(ExtCmd):
 
         if not global_cfg.cleanup:
             return
-        with Context('netpol_cross_ns_cleanup', brief_report=True) as ctx:
+        with Context(ovn, 'netpol_cross_ns_cleanup', brief_report=True) as ctx:
             for ns in all_ns:
                 ns.unprovision()

--- a/ovn-tester/tests/netpol_multitenant.py
+++ b/ovn-tester/tests/netpol_multitenant.py
@@ -72,7 +72,7 @@ class NetpolMultitenant(ExtCmd):
         ]
 
         all_ns = []
-        with Context('netpol_multitenant', self.config.n_namespaces,
+        with Context(ovn, 'netpol_multitenant', self.config.n_namespaces,
                      test=self) as ctx:
             for i in ctx:
                 # Get the number of pods from the "highest" range that
@@ -94,6 +94,7 @@ class NetpolMultitenant(ExtCmd):
 
         if not global_cfg.cleanup:
             return
-        with Context('netpol_multitenant_cleanup', brief_report=True) as ctx:
+        with Context(ovn, 'netpol_multitenant_cleanup',
+                     brief_report=True) as ctx:
             for ns in all_ns:
                 ns.unprovision()


### PR DESCRIPTION
Adding an extra 'ovn-nbctl sync' while exiting test contexts,
so previous test stages doesn't skew results for later ones.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>