### PR TITLE
ovn-tester: Fix nbctl sync timeout.

### DIFF
--- a/ovn-tester/ovn_context.py
+++ b/ovn-tester/ovn_context.py
@@ -31,7 +31,7 @@ class Context(object):
 
     def __exit__(self, type, value, traceback):
         log.info('Waiting for the OVN state synchronization')
-        self.cluster.nbctl.run('--timeout=1800 --wait=hv sync')
+        self.cluster.nbctl.sync(timeout=1800)
         ovn_stats.report(self.test_name, brief=self.brief_report)
         log.info(f'Exiting context {self.test_name}')
 


### PR DESCRIPTION
Currently 'ovn-nbctl sync' is executed via Sandbox class that has a
default 60 second timeout on all operations.  This means that
synchronization longer than one minute will be terminated:

 14:04:02 | ovn_context  |INFO| Waiting for the OVN state synchronization
 14:05:02 | ovn_sandbox  |WARNING| Command
        "ovn-nbctl -u /var/run/ovn/ovn-nbctl.ctl
                --timeout=1800 --wait=hv sync ;"
        timed out!
 14:05:02 | ovn_sandbox  |INFO| Result: [''], Exit status: 42

Fix that by introducing a generic 'timeout' option to all Sandbox
derived run() methods.  Default value is 60 seconds, but can be
overwritten by the caller.  Currently only used for nbctl sync that
will have 30 minutes to complete.  Execution timeout set slightly
higher than nbctl timeout option to allow the nbctl call to terminate
itself gracefully, so we can continue using the same shell.

Also re-using existing nbctl.sync() method instead of calling
the command directly.

Not introducing timeout for PhysicalNode.run(), because paramiko's
exec_command() will apply timeout only to reads, while
recv_exit_status() will not respect it and wait indefinitely anyway.
Some re-work of the SSH.run() is required to correctly support
timeouts for physical node executions.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>