### PR TITLE
Update maximum number of SSH sessions and fs notifiers

### DIFF
--- a/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
+++ b/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
@@ -20,6 +20,16 @@
       ./ovn_cluster.sh stop
       docker system prune -f
 
+  - name: Ensure number of inotify instances for containers
+    shell: |
+      sysctl -w fs.inotify.max_user_instances=2048
+
+  - name: Ensure the number of allowed SSH sessions
+    shell: |
+      sed -i '/^MaxSessions /d' /etc/ssh/sshd_config
+      echo "MaxSessions 1024" >> /etc/ssh/sshd_config
+      systemctl reload sshd.service
+
   - name: Create ovs bridges for ovn fake multinode
     shell: |
       set -e


### PR DESCRIPTION
Without these changes the host will not be able to run more than
10-ish containers.  The default value for MaxSessions is only 10,
defualt value for fs.inotify.max_user_instances also allows to
start only 10-12 containers on the host:

 ovn-scale-59: Failed to create control group inotify object: Too many open files
 ovn-scale-59: Failed to allocate manager object: Too many open files
 ovn-scale-59: [!!!!!!] Failed to allocate manager object.

Issues can be easily triggered by attempting to run 20 or 60
node tests on localhost.

Chosen values should allow to run any reasonable number of fake
nodes per physical machine.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>