### PR TITLE
ovn_tester: Enable northd parallelization.

### DIFF
--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -209,6 +209,7 @@ def read_config(config):
         static_vips=static_vips,
         static_vips6=static_vips6,
         use_ovsdb_etcd=cluster_args.get('use_ovsdb_etcd', False),
+        northd_threads=cluster_args.get('northd_threads', 4),
     )
     brex_cfg = BrExConfig(
         physical_net=cluster_args.get('physical_net', 'providernet'),


### PR DESCRIPTION
OpenShift is using northd parallelization with 4 threads by default.
ovn-heater should do that as well.  Can be configured by setting
'northd_threads' in the test yml.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>