### PR TITLE
Ensure the neighbor cache size on central nodes is sufficient

### DIFF
--- a/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
+++ b/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
@@ -30,6 +30,13 @@
       echo "MaxSessions 1024" >> /etc/ssh/sshd_config
       systemctl reload sshd.service
 
+  - name: Ensure the neighbor cache size on central nodes
+    when: ovn_central is defined
+    shell: |
+      sysctl -w net.ipv4.neigh.default.gc_thresh1=8192
+      sysctl -w net.ipv4.neigh.default.gc_thresh2=32768
+      sysctl -w net.ipv4.neigh.default.gc_thresh3=65536
+
   - name: Create ovs bridges for ovn fake multinode
     shell: |
       set -e


### PR DESCRIPTION
In high-scale tests the kernel on central nodes complains:

  kernel: neighbour: arp_cache: neighbor table overflow!

This is due to large number of incoming database connections from
all other nodes.  Setting up higher cache size to avoid the problem.

Values are taken from a live ovn-kubernetes cluster.

Not using ansible's 'sysctl' module to avoid setting these values
permanently.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>