### PR TITLE
ovn_workload: Align router configuration with ovn-kubernetes.

### DIFF
--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -361,12 +361,12 @@ class OvnNbctl:
         cmd = f'add Logical_Router {lr.uuid} load_balancer_group {lbg.uuid}'
         self.run(cmd=cmd)
 
-    def lr_set_lb_force_snat_ip(self, router, ip):
-        # Build lb_force_snat_ip of the form: '"v4-ip v6-ip"'
-        snat_ips = [str(val) for val in filter(lambda v: v, [ip.ip4, ip.ip6])]
-        snat_ip_str = f'\"{" ".join(snat_ips)}\"'
-        self.run(f'set Logical_Router {router.name} '
-                 f'options:lb_force_snat_ip={snat_ip_str}')
+    def lr_set_options(self, router, options):
+        opt = ''
+        for key, value in options.items():
+            opt = opt + f' options:{key}={value}'
+
+        self.run(f'set Logical_Router {router.name} {opt}')
 
     def lb_set_vips(self, lb, vips):
         vip_str = ''


### PR DESCRIPTION
ovn-kubernetes sets different values for a lot of router options.
Fot example, it sets 'dynamic_neigh_routers' on all node gateway
routers.  This has a significant impact on the amount of logical
flows OVN generates.  For example, by enabling this option in
ovn-heater, number of logical flows in 500-node density-heavy
run is reduced from 790 K down to 290 K.  That has a significant
impact on the database size and the cluster operation.

Other options will also have impact on the actually generated
logical flows.

Values are taken from the current ovn-kubernetes.

Node gateway router:
  https://github.com/ovn-org/ovn-kubernetes/blob/f78409cb6791225421c73936c6419d4483b14414/go-controller/pkg/ovn/gateway_init.go#L38

Cluster router:
  https://github.com/ovn-org/ovn-kubernetes/blob/f78409cb6791225421c73936c6419d4483b14414/go-controller/pkg/ovn/master.go#L347

We can make some of these options configurable in the future.

Signed-off-by: Ilya Maximets <i.maximets@ovn.org>