### PR TITLE
cirrus: Check low-scale run in Cirrus CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,57 @@
+low_scale_task:
+
+  compute_engine_instance:
+    image_project: fedora-cloud
+    image: family/fedora-cloud-35
+    platform: linux
+    memory: 8G
+
+  env:
+    DEPENDENCIES: git ansible podman podman-docker
+    PHYS_DEPLOYMENT: ${CIRRUS_WORKING_DIR}/physical-deployments/localhost.yml
+
+  runtime_cache:
+    folder: runtime-cache
+
+  configure_ssh_script:
+    - mkdir -p /root/.ssh/
+    - ssh-keygen -t rsa -N '' -q -f /root/.ssh/id_rsa
+    - ssh-keyscan localhost >> /root/.ssh/known_hosts
+    - cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+    - chmod og-wx /root/.ssh/authorized_keys
+    - ssh root@localhost -v echo Hello
+
+  install_dependencies_script:
+    - dnf install -y ${DEPENDENCIES}
+
+  unpack_caches_script:
+    - mkdir -p runtime runtime-cache
+    - docker load -i runtime-cache/ovn-multi-node.tar || true
+    - tar -xzf runtime-cache/runtime.tar.gz || true
+
+  install_script:
+    - ./do.sh install
+
+  pack_caches_script:
+    - rm -rf runtime-cache/*
+    - docker save -o runtime-cache/ovn-multi-node.tar ovn/ovn-multi-node:latest
+    - tar -czf runtime-cache/runtime.tar.gz runtime
+
+  upload_caches:
+    - runtime
+
+  test_script:
+    - 'sed -i "s/^  log_cmds\: False/  log_cmds\: True/"
+        test-scenarios/ovn-low-scale.yml'
+    - 'sed -i
+        "/^cluster:/a \ \ cluster_cmd_path: $(pwd)/runtime/ovn-fake-multinode"
+        test-scenarios/ovn-low-scale.yml'
+    - ./do.sh run test-scenarios/ovn-low-scale.yml low-scale
+
+  check_logs_script:
+    - '! grep -B 30 -A 30 "Result: FAIL" ./test_results/*/test-log'
+    - grep "Result: SUCCESS" ./test_results/*/test-log
+
+  always:
+    test_logs_artifacts:
+      path: test_results/**

--- a/do.sh
+++ b/do.sh
@@ -87,7 +87,10 @@ EOF
 
 function install_venv() {
     pushd ${rundir}
-    python3 -m virtualenv ${ovn_heater_venv}
+    if [ ! -f ${ovn_heater_venv}/bin/activate ]; then
+        rm -rf ${ovn_heater_venv}
+        python3 -m virtualenv ${ovn_heater_venv}
+    fi
     source ${ovn_heater_venv}/bin/activate
     pip install -r ${ovn_tester}/requirements.txt
     deactivate

--- a/physical-deployments/localhost.yml
+++ b/physical-deployments/localhost.yml
@@ -1,0 +1,8 @@
+registry-node: localhost
+internal-iface: lo
+
+central-node:
+  name: localhost
+
+worker-nodes:
+  - localhost


### PR DESCRIPTION
Add a Cirrus CI configuration YAML file with the job to run a minimal
low-scale test.  It is practically not possible or extremely hard to
do the same in GitHub Actions for few reasons:

 - In GHA we're already inside of a container.
 - This container is ubuntu-based.
 - ovn-heater dosn't support debian-based distributions so we need to
   run a nested container.
 - Using a 'container:' config we can run a fedora container, but the
   container command is always overwritten, so no way to run a
   container with systemd as init.
 - I failed to start any container with systemd as init manually.
 - 'runner' is not a root, most of the operations require 'sudo',
   but we will ssh to localhost without using sudo afterwards, even
   if the user is replaced with 'runner' in ansible configuration.
 - Many more environment quirks that doesn't allow you to do what
   you actually need.

Cirrus CI's default containers are similar to GHA, but with Cirrus CI
we're able to just start a plain fedora-cloud VM and have a full access
to it as root.

'runtime' is cached to speed up builds.  Command logging enabled to
simplify troubleshooting.  Container image is cached as well.
'runtime' is archived to avoid symlink breakage.

Since we're re-constructing and re-packing many parts of the 'runtime',
the cache will be re-uploaded every time.  But, at least, we're not
re-building it, which is the main part.

Added a check for already existing venv to allow re-using a cached
version.

Reported-at: https://github.com/dceara/ovn-heater/issues/126
Signed-off-by: Ilya Maximets <i.maximets@ovn.org>