### PR TITLE
test-scenarios: Add 500-node cases.

### DIFF
--- a/test-scenarios/ocp-500-cluster-density.yml
+++ b/test-scenarios/ocp-500-cluster-density.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 500
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+cluster_density:
+  n_startup: 7800
+  n_runs: 8000

--- a/test-scenarios/ocp-500-density-heavy.yml
+++ b/test-scenarios/ocp-500-density-heavy.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 500
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+density_heavy:
+  n_startup: 22250
+  n_pods: 22500

--- a/test-scenarios/ocp-500-density-light.yml
+++ b/test-scenarios/ocp-500-density-light.yml
@@ -1,0 +1,14 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 500
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+density_light:
+  n_startup: 121250
+  n_pods: 122500

--- a/test-scenarios/ocp-500-np-multitenant.yml
+++ b/test-scenarios/ocp-500-np-multitenant.yml
@@ -1,0 +1,23 @@
+global:
+  log_cmds: False
+
+cluster:
+  clustered_db: true
+  monitor_all: true
+  n_workers: 500
+
+base_cluster_bringup:
+  n_pods_per_node: 10
+
+netpol_multitenant:
+  n_namespaces: 500
+  ranges:
+    - r1:
+      start:   200
+      n_pods:  5
+    - r2:
+      start:   480
+      n_pods:  20
+    - r3:
+      start:   495
+      n_pods:  100


### PR DESCRIPTION
'cluster-density' scenarios are a bit uneven, e.g. it jumps from 1000 runs to 4000 between 120 and 250 node.  Just doubling that value for 500-node case.

Other tests just scaled linearly according to values in smaller ones.

Signed-off-by: Ilya Maximets \<i.maximets@ovn.org\>