### PR TITLE
do.sh: Mine data about crashed OVS/OVN daemons.

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -307,6 +307,10 @@ function mine_data() {
 
     rm -rf ./mined-data/ovn-binding.log ./mined-data/ovn-installed.log
 
+    logs=$(find ${out_dir}/logs -iname 'ps*')
+    grep died ${logs} | sed 's/.*\/\(ovn-.*\)/\1/' > mined-data/crashes
+    [ -s mined-data/crashes ] || rm -f mined-data/crashes
+
     resource_usage_logs=$(find ${out_dir}/logs -name process-stats.json \
                             | grep -v ovn-scale)
     python3 ${topdir}/utils/process-stats.py \


### PR DESCRIPTION
Monitor processes hold the health information in the process name. E.g.:

```
  ovsdb-server: monitoring pid 349 (1 crashes: pid 211 died,
                                    killed (Aborted), core dumped)
```

Grep out all such strings from the output of ps to a separate file to be able to quickly spot crashes at a glance.

Do not create a file if nothing to report.

Signed-off-by: Ilya Maximets \<i.maximets@ovn.org\>