### PR TITLE
Centralize YAML Defaults

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,6 @@ low_scale_task:
     image: family/fedora-cloud-35
     platform: linux
     memory: 8G
-    use_static_ip: true
 
   env:
     DEPENDENCIES: git ansible podman podman-docker
@@ -15,7 +14,10 @@ low_scale_task:
     folder: runtime-cache
 
   configure_ssh_script:
-    - export IP_ADDR=$(ip route get 8.8.8.8 | head -1 | sed 's/.*src \([0-9\.]*\).*/\1/')
+    - |
+      export IP_ADDR=$(ip route get 8.8.8.8 | \
+      head -1 | \
+      sed 's/.*src \([0-9\.]*\).*/\1/')
     - mkdir -p /root/.ssh/
     - ssh-keygen -t rsa -N '' -q -f /root/.ssh/id_rsa
     - ssh-keyscan ${IP_ADDR} >> /root/.ssh/known_hosts
@@ -32,7 +34,10 @@ low_scale_task:
     - tar -xzf runtime-cache/runtime.tar.gz || true
 
   install_script:
-    - export IP_ADDR=$(ip route get 8.8.8.8 | head -1 | sed 's/.*src \([0-9\.]*\).*/\1/')
+    - |
+      export IP_ADDR=$(ip route get 8.8.8.8 | \
+      head -1 | \
+      sed 's/.*src \([0-9\.]*\).*/\1/')
     - 'sed -i "s/<ip>/${IP_ADDR}/g" ${PHYS_DEPLOYMENT}'
     - ./do.sh install
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,16 +14,12 @@ low_scale_task:
     folder: runtime-cache
 
   configure_ssh_script:
-    - |
-      export IP_ADDR=$(ip route get 8.8.8.8 | \
-      head -1 | \
-      sed 's/.*src \([0-9\.]*\).*/\1/')
     - mkdir -p /root/.ssh/
     - ssh-keygen -t rsa -N '' -q -f /root/.ssh/id_rsa
-    - ssh-keyscan ${IP_ADDR} >> /root/.ssh/known_hosts
+    - ssh-keyscan $(hostname) >> /root/.ssh/known_hosts
     - cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
     - chmod og-wx /root/.ssh/authorized_keys
-    - ssh root@${IP_ADDR} -v echo Hello
+    - ssh root@$(hostname) -v echo Hello
 
   install_dependencies_script:
     - dnf install -y ${DEPENDENCIES}
@@ -34,11 +30,7 @@ low_scale_task:
     - tar -xzf runtime-cache/runtime.tar.gz || true
 
   install_script:
-    - |
-      export IP_ADDR=$(ip route get 8.8.8.8 | \
-      head -1 | \
-      sed 's/.*src \([0-9\.]*\).*/\1/')
-    - 'sed -i "s/<ip>/${IP_ADDR}/g" ${PHYS_DEPLOYMENT}'
+    - 'sed -i "s/<host>/$(hostname)/g" ${PHYS_DEPLOYMENT}'
     - ./do.sh install
 
   pack_caches_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,21 +5,23 @@ low_scale_task:
     image: family/fedora-cloud-35
     platform: linux
     memory: 8G
+    use_static_ip: true
 
   env:
     DEPENDENCIES: git ansible podman podman-docker
-    PHYS_DEPLOYMENT: ${CIRRUS_WORKING_DIR}/physical-deployments/localhost.yml
+    PHYS_DEPLOYMENT: ${CIRRUS_WORKING_DIR}/physical-deployments/ci.yml
 
   runtime_cache:
     folder: runtime-cache
 
   configure_ssh_script:
+    - export IP_ADDR=$(ip route get 8.8.8.8 | head -1 | sed 's/.*src \([0-9\.]*\).*/\1/')
     - mkdir -p /root/.ssh/
     - ssh-keygen -t rsa -N '' -q -f /root/.ssh/id_rsa
-    - ssh-keyscan localhost >> /root/.ssh/known_hosts
+    - ssh-keyscan ${IP_ADDR} >> /root/.ssh/known_hosts
     - cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
     - chmod og-wx /root/.ssh/authorized_keys
-    - ssh root@localhost -v echo Hello
+    - ssh root@${IP_ADDR} -v echo Hello
 
   install_dependencies_script:
     - dnf install -y ${DEPENDENCIES}
@@ -30,6 +32,8 @@ low_scale_task:
     - tar -xzf runtime-cache/runtime.tar.gz || true
 
   install_script:
+    - export IP_ADDR=$(ip route get 8.8.8.8 | head -1 | sed 's/.*src \([0-9\.]*\).*/\1/')
+    - 'sed -i "s/<ip>/${IP_ADDR}/g" ${PHYS_DEPLOYMENT}'
     - ./do.sh install
 
   pack_caches_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ RUN mkdir -p /root/.ssh/
 COPY $SSH_KEY /root/.ssh/
 
 COPY $PHYS_DEPLOYMENT /physical-deployment.yml
+COPY ovn-fake-multinode-utils/process-monitor.py /tmp/
 
 RUN pip3 install -r /ovn-tester/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ovn/ovn-multi-node
+
+ARG SSH_KEY
+ARG PHYS_DEPLOYMENT
+
+COPY ovn-tester /ovn-tester
+
+RUN mkdir -p /root/.ssh/
+COPY $SSH_KEY /root/.ssh/
+
+COPY $PHYS_DEPLOYMENT /physical-deployment.yml
+
+RUN pip3 install -r /ovn-tester/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM ovn/ovn-multi-node
 
 ARG SSH_KEY
-ARG PHYS_DEPLOYMENT
 
 COPY ovn-tester /ovn-tester
 
 RUN mkdir -p /root/.ssh/
 COPY $SSH_KEY /root/.ssh/
 
-COPY $PHYS_DEPLOYMENT /physical-deployment.yml
 COPY ovn-fake-multinode-utils/process-monitor.py /tmp/
 
 RUN pip3 install -r /ovn-tester/requirements.txt

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ insecure docker registries, cleanup existing docker containers).
 
 ## Physical topology
 
-* TESTER: One machine to run the tests which needs to be able to SSH
-  paswordless (preferably as `root`) to all other machines in the topology.
-  Performs the following:
+* ORCHESTRATOR: One machine that needs to be able to SSH paswordless
+  (preferably as `root`) to all other machines in the topology. Performs the
+  following:
   - prepares the test enviroment: clone the specified versions of `OVS` and
     `OVN` and build the `ovn-fake-multinode` image to be used by the `OVN`
     nodes.
@@ -22,10 +22,12 @@ insecure docker registries, cleanup existing docker containers).
     and with the correct version of `ovn-fake-multinode` to run simulated/fake
     `OVN` chassis.
   - runs a docker registry where the `ovn-fake-multinode` (i.e.,
-    `ovn/ovn-multi-node`) image is pushed and from which all other `OVN`
-    nodes will pull the image.
-  - runs the scale test scenarios.
+    `ovn/ovn-multi-node`) and `ovn-tester` images are pushed and from which all
+    other `OVN` nodes will pull the image.
 
+* TESTER: One machine to run the `ovn-tester` container which runs the python
+  ovn-tester code. Like the ORCHESTRATOR, the TESTER also needs to be able to
+  SSH passwordless to all other machines in the topology.
 * OVN-CENTRAL: One machine to run the `ovn-central` container(s) which
   run `ovn-northd` and the `Northbound` and `Southbound` databases.
 * OVN-WORKER-NODE(s): Machines to run `ovn-netlab` container(s), each of
@@ -41,12 +43,12 @@ single L2 switch. This interface will be used for traffic to/from the
 `Northbound` and `Southbound` databases and for tunneled traffic.
 
 **NOTE**: there's no restriction regarding physical machine roles so for
-debugging issues the TESTER, OVN-CENTRAL and OVN-WORKER-NODEs can all
-be the same physical machine in which case there's no need for the secondary
-Ethernet interface to exist.
+debugging issues the ORCHESTRATOR, TESTER, OVN-CENTRAL and OVN-WORKER-NODEs can
+all be the same physical machine in which case there's no need for the
+secondary Ethernet interface to exist.
 
 ## Sample physical topology:
-* TESTER: `host01.mydomain.com`
+* ORCHESTRATOR: `host01.mydomain.com`
 * OVN-CENTRAL: `host02.mydomain.com`
 * OVN-WORKER-NODEs:
   - `host03.mydomain.com`
@@ -55,14 +57,22 @@ Ethernet interface to exist.
 OVN-CENTRAL and OVN-WORKER-NODEs all have Ethernet interface `eno1`
 connected to a physical switch in a separate VLAN, as untagged interfaces.
 
-## Minimal requirements on the TESTER node (tested on Fedora 32)
+**NOTE**: The hostnames specified in the physical topology are used by both
+the ORCHESTRATOR and by the `ovn-tester` container running in the TESTER.
+Therefore, the values need to be resolvable by both of these entities and
+need to resolve to the same host. `localhost` will not work since this does
+not resolve to a unique host.
+
+## Minimal requirements on the ORCHESTRATOR node (tested on Fedora 32)
 
 ### Install required packages:
 ```
 dnf install -y git ansible
 ```
 
-### Make docker work with Fedora 32 (disable cgroup hierarchy):
+## Minimal requirements on the TESTER node (tested on Fedora 36)
+
+### Make docker work with Fedora 32+ (disable cgroup hierarchy):
 
 ```
 dnf install -y grubby
@@ -107,10 +117,16 @@ A sample file written for the deployment described above is available at
 
 The file should contain the following mandatory sections and fields:
 - `registry-node`: the hostname (or IP) of the node that will store the
-  docker private registry. In usual cases this is should be the TESTER
+  docker private registry. In usual cases this is should be the ORCHESTRATOR
   machine.
 - `internal-iface`: the name of the Ethernet interface used by the underlay
   (DB and tunnel traffic). This can be overridden per node if needed.
+- `tester-node`:
+  - `name`: the hostname (or IP) of the node that will run `ovn-tester` (the
+    python code that performs the actual test)
+  - `ssh_key`: An ssh private key to install in the TESTER that can be used
+    to communicate with the other machines in the cluster.
+    Default: `~/.ssh/id_rsa`
 - `central-node`:
   - `name`: the hostname (or IP) of the node that will run `ovn-central`
     (`ovn-northd` and databases).
@@ -231,10 +247,11 @@ cd ~/ovn-heater
 ./do.sh run <scenario> <results-dir>
 ```
 
-This executes `<scenario>` on the physical deployment. Current
-scenarios also cleanup the environment, i.e., remove all docker containers
-from all physical nodes. **NOTE**: If the environment needs to be explictly
-cleaned up, we can also execute before running the scenario:
+This executes `<scenario>` on the physical deployment (specifically on the
+`ovn-tester` container on the TESTER). Current scenarios also cleanup the
+environment, i.e., remove all docker containers from all physical nodes.
+**NOTE**: If the environment needs to be explictly cleaned up, we can also
+execute before running the scenario:
 
 ```
 cd ~/ovn-heater

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ This step will:
   can be enabled by setting the `EXTRA_OPTIMIZE=yes` environment variable
   (`EXTRA_OPTIMIZE=yes ./do.sh install`).
 - push the container image to all other nodes and prepare the test environment.
+- build the `ovn/ovn-tester` container image which will be used by the TESTER
+  node to run the ovn-tester application.
+- push the `ovn/ovn-tester` container image to the TESTER node.
 
 To override the OVS, OVN or ovn-fake-multinode repos/branches use the
 following environment variables:
@@ -191,6 +194,10 @@ For example, installing components with custom OVS/OVN code:
 cd ~/ovn-heater
 OVS_REPO=https://github.com/dceara/ovs OVS_BRANCH=tmp-branch OVN_REPO=https://github.com/dceara/ovn OVN_BRANCH=tmp-branch-2 ./do.sh install
 ```
+
+NOTE: Because the installation step is responsible for deploying the ovn-tester
+container to the TESTER, this means that if any changes are made to the
+ovn-tester application, the installation step must be re-run.
 
 ## Perform a reinstallation (e.g., new OVS/OVN versions are needed):
 

--- a/do.sh
+++ b/do.sh
@@ -304,10 +304,16 @@ function record_test_config() {
 
 function mine_data() {
     out_dir=$1
+    tester_host=$2
 
     echo "-- Mining data from logs in: ${out_dir}"
 
     pushd ${out_dir}
+    # Prior to containerization of ovn-tester, HTML files written by ovn-tester
+    # were written directly to ${out_dir}. To make things easier for tools, we
+    # copy the HTML files back to this original location.
+    cp logs/${tester_host}/ovn-tester/*.html ${out_dir}
+
     mkdir -p mined-data
     for p in ovn-northd ovn-controller ovn-nbctl; do
         logs=$(find ${out_dir}/logs -name ${p}.log)
@@ -403,10 +409,6 @@ function run_test() {
     for f in *.tgz; do
        tar xvfz $f
     done
-    # Prior to containerization of ovn-tester, HTML files written by ovn-tester
-    # were written directly to ${out_dir}. To make things easier for tools, we
-    # copy the HTML files back to this original location.
-    cp ${tester_host}/ovn-tester/*.html ${out_dir}
 
     # Once we successfully ran the test and collected its logs, the post
     # processing (e.g., data mining) can run in a subshell with errexit
@@ -414,7 +416,7 @@ function run_test() {
     # processing fails.
     (
         set +o errexit
-        mine_data ${out_dir}
+        mine_data ${out_dir} ${tester_host}
     )
 }
 

--- a/do.sh
+++ b/do.sh
@@ -309,10 +309,6 @@ function mine_data() {
     echo "-- Mining data from logs in: ${out_dir}"
 
     pushd ${out_dir}
-    # Prior to containerization of ovn-tester, HTML files written by ovn-tester
-    # were written directly to ${out_dir}. To make things easier for tools, we
-    # copy the HTML files back to this original location.
-    cp logs/${tester_host}/ovn-tester/*.html ${out_dir}
 
     mkdir -p mined-data
     for p in ovn-northd ovn-controller ovn-nbctl; do
@@ -409,6 +405,10 @@ function run_test() {
     for f in *.tgz; do
        tar xvfz $f
     done
+    # Prior to containerization of ovn-tester, HTML files written by ovn-tester
+    # were written directly to ${out_dir}. To make things easier for tools, we
+    # copy the HTML files back to this original location.
+    cp logs/${tester_host}/ovn-tester/*.html ${out_dir} || true
 
     # Once we successfully ran the test and collected its logs, the post
     # processing (e.g., data mining) can run in a subshell with errexit

--- a/do.sh
+++ b/do.sh
@@ -356,20 +356,11 @@ function mine_data() {
 function get_tester_ip() {
     local test_file=$1
 
+    # The tester gets the first IP address in the configured node_net.
     node_net=$(${ovn_fmn_get} ${test_file} cluster node_net --default=192.16.0.0/16)
     node_cidr=${node_net#*/}
     node_ip=${node_net%/*}
     ip_index=1
-    clustered_db=$(${ovn_fmn_get} ${test_file} cluster clustered_db --default=True)
-    # The yaml loader normalizes "yes" and "no" values for clustered_db into
-    # "True" and "False"
-    if [ "${clustered_db}" = "True" ]; then
-        (( ip_index += 3 ))
-    else
-        (( ip_index += 1 ))
-    fi
-    n_relays=$(${ovn_fmn_get} ${test_file} cluster n_relays --default=0)
-    (( ip_index += ${n_relays} ))
     tester_ip=$(${ovn_fmn_ip} ${node_net} ${node_ip} ${ip_index})
     echo "${tester_ip}/${node_cidr}"
 }

--- a/do.sh
+++ b/do.sh
@@ -332,7 +332,7 @@ function mine_data() {
         | cut -d ' ' -f 1,7 | tr 'T' ' ' | sort > mined-data/ovn-installed.log
 
     source ${rundir}/${ovn_heater_venv}/bin/activate
-    python3 ${topdir}/utils/latency.py "$(date +%z)" \
+    python3 ${topdir}/utils/latency.py \
         ./mined-data/ovn-binding.log ./mined-data/ovn-installed.log \
         > mined-data/binding-to-ovn-installed-latency
 

--- a/do.sh
+++ b/do.sh
@@ -397,7 +397,7 @@ function run_test() {
     # Prior to containerization of ovn-tester, HTML files written by ovn-tester
     # were written directly to ${out_dir}. To make things easier for tools, we
     # copy the HTML files back to this original location.
-    cp logs/${tester_host}/ovn-tester/*.html ${out_dir} || true
+    cp ${tester_host}/ovn-tester/*.html ${out_dir} || true
 
     # Once we successfully ran the test and collected its logs, the post
     # processing (e.g., data mining) can run in a subshell with errexit

--- a/do.sh
+++ b/do.sh
@@ -236,10 +236,8 @@ function install_ovn_tester() {
     # We need to copy the files into a known directory within the Docker
     # context directory. Otherwise, Docker can't find the files we reference.
     cp ${ssh_key} tester_files
-    cp ${phys_deployment} tester_files
     ssh_key_file=tester_files/$(basename ${ssh_key})
-    phys_deployment_file=tester_files/$(basename ${phys_deployment})
-    docker build -t ovn/ovn-tester --build-arg SSH_KEY=${ssh_key_file} --build-arg PHYS_DEPLOYMENT=${phys_deployment_file} -f ${topdir}/Dockerfile .
+    docker build -t ovn/ovn-tester --build-arg SSH_KEY=${ssh_key_file} -f ${topdir}/Dockerfile .
     docker tag ovn/ovn-tester localhost:5000/ovn/ovn-tester
     docker push localhost:5000/ovn/ovn-tester
     rm -rf tester_files
@@ -380,7 +378,7 @@ function run_test() {
     init_ovn_fake_multinode
 
     tester_ip=$(get_tester_ip ${test_file})
-    if ! ansible-playbook ${ovn_fmn_playbooks}/run-tester.yml -i ${hosts_file} --extra-vars "test_file=${test_file} tester_ip=${tester_ip}" ; then
+    if ! ansible-playbook ${ovn_fmn_playbooks}/run-tester.yml -i ${hosts_file} --extra-vars "test_file=${test_file} tester_ip=${tester_ip} phys_deployment=${phys_deployment}" ; then
          echo "-- Failed to set up test!"
     fi
 

--- a/do.sh
+++ b/do.sh
@@ -375,7 +375,7 @@ function run_test() {
 
     tester_ip=$(get_tester_ip ${test_file})
     if ! ansible-playbook ${ovn_fmn_playbooks}/run-tester.yml -i ${hosts_file} --extra-vars "test_file=${test_file} tester_ip=${tester_ip} phys_deployment=${phys_deployment}" ; then
-         echo "-- Failed to set up test!"
+        die "-- Failed to set up test!"
     fi
 
     tester_host=$(${ovn_fmn_get} ${phys_deployment} tester-node name)

--- a/ovn-fake-multinode-utils/generate-hosts.py
+++ b/ovn-fake-multinode-utils/generate-hosts.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import helpers
 import yaml
 import sys
+from pathlib import Path
 
 
 def usage(name):
@@ -35,6 +36,22 @@ def generate_node(config, user, prefix, internal_iface, **kwargs):
     )
 
 
+def generate_tester(config, user, prefix, internal_iface):
+    ssh_key = config.get("ssh_key")
+    if ssh_key is None:
+        ssh_key = Path.home().joinpath(".ssh/id_rsa")
+    else:
+        ssh_key = Path(ssh_key).resolve()
+    generate_node(
+        config,
+        user,
+        prefix,
+        internal_iface,
+        ovn_tester="true",
+        ssh_key=str(ssh_key),
+    )
+
+
 def generate_controller(config, user, prefix, internal_iface):
     generate_node(config, user, prefix, internal_iface, ovn_central="true")
 
@@ -59,9 +76,11 @@ def generate(input_file, target, repo, branch):
         prefix = config.get('prefix', 'ovn-scale')
         registry_node = config['registry-node']
         central_config = config['central-node']
+        tester_config = config['tester-node']
 
         print('[ovn_hosts]')
         internal_iface = config['internal-iface']
+        generate_tester(tester_config, user, prefix, internal_iface)
         generate_controller(central_config, user, prefix, internal_iface)
         generate_workers(config['worker-nodes'], user, prefix, internal_iface)
         print()

--- a/ovn-fake-multinode-utils/generate-hosts.py
+++ b/ovn-fake-multinode-utils/generate-hosts.py
@@ -9,37 +9,47 @@ import sys
 
 def usage(name):
     print(
-        """
-{} DEPLOYMENT ovn-fake-multinode-target github-repo branch
+        f"""
+{name} DEPLOYMENT ovn-fake-multinode-target github-repo branch
 where DEPLOYMENT is the YAML file defining the deployment.
-""".format(
-            name
-        ),
+""",
         file=sys.stderr,
     )
 
 
-def generate_nodes(nodes_config, user, prefix, internal_iface):
-    for node_config in nodes_config:
-        host, node_config = helpers.get_node_config(node_config)
-        iface = node_config.get('internal-iface', internal_iface)
-        generate_worker(host, user, prefix, iface)
+def generate_node_string(host, **kwargs):
+    args = ' '.join(f"{key}={value}" for key, value in kwargs.items())
+    print(f"{host} {args}")
+
+
+def generate_node(config, user, prefix, internal_iface, **kwargs):
+    host = config['name']
+    internal_iface = config.get('internal-iface', internal_iface)
+    generate_node_string(
+        host,
+        ansible_user=user,
+        become="true",
+        internal_iface=internal_iface,
+        node_name=prefix,
+        **kwargs,
+    )
 
 
 def generate_controller(config, user, prefix, internal_iface):
-    host = config['name']
-    internal_iface = config.get('internal-iface', internal_iface)
-    print(
-        '{} ansible_user=root become=true internal_iface={} '
-        'node_name={} ovn_central=true'.format(host, internal_iface, prefix)
-    )
+    generate_node(config, user, prefix, internal_iface, ovn_central="true")
 
 
-def generate_worker(host, user, prefix, internal_iface):
-    print(
-        '{} ansible_user=root become=true internal_iface={} '
-        'node_name={}'.format(host, internal_iface, prefix)
-    )
+def generate_workers(nodes_config, user, prefix, internal_iface):
+    for node_config in nodes_config:
+        host, node_config = helpers.get_node_config(node_config)
+        iface = node_config.get('internal-iface', internal_iface)
+        generate_node_string(
+            host,
+            ansible_user=user,
+            become="true",
+            internal_iface=iface,
+            node_name=prefix,
+        )
 
 
 def generate(input_file, target, repo, branch):
@@ -53,7 +63,7 @@ def generate(input_file, target, repo, branch):
         print('[ovn_hosts]')
         internal_iface = config['internal-iface']
         generate_controller(central_config, user, prefix, internal_iface)
-        generate_nodes(config['worker-nodes'], user, prefix, internal_iface)
+        generate_workers(config['worker-nodes'], user, prefix, internal_iface)
         print()
 
         print('[ovn_hosts:vars]')

--- a/ovn-fake-multinode-utils/generate-hosts.py
+++ b/ovn-fake-multinode-utils/generate-hosts.py
@@ -37,11 +37,8 @@ def generate_node(config, user, prefix, internal_iface, **kwargs):
 
 
 def generate_tester(config, user, prefix, internal_iface):
-    ssh_key = config.get("ssh_key")
-    if ssh_key is None:
-        ssh_key = Path.home().joinpath(".ssh/id_rsa")
-    else:
-        ssh_key = Path(ssh_key).resolve()
+    ssh_key = config["ssh_key"]
+    ssh_key = Path(ssh_key).resolve()
     generate_node(
         config,
         user,

--- a/ovn-fake-multinode-utils/get-config-value.py
+++ b/ovn-fake-multinode-utils/get-config-value.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import argparse
 import yaml
 

--- a/ovn-fake-multinode-utils/get-config-value.py
+++ b/ovn-fake-multinode-utils/get-config-value.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import argparse
+import yaml
+
+
+def parser_setup(parser):
+    group = parser.add_argument_group()
+    group.add_argument(
+        "config",
+        metavar="CONFIG_FILE",
+        help="Configuration file",
+    )
+    group.add_argument(
+        "section",
+        metavar="SECTION",
+        help="Configuration file section",
+    )
+    group.add_argument(
+        "variable", metavar="VAR", help="Configuration variable to retrieve"
+    )
+    group.add_argument(
+        "--default", help="Default value if VAR is not in CONFIG"
+    )
+
+
+def get_config_value(args):
+    with open(args.config, 'r') as config_file:
+        parsed = yaml.safe_load(config_file)
+
+    try:
+        return parsed[args.section][args.variable]
+    except KeyError:
+        if args.default:
+            return args.default
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read YAML config value")
+    parser_setup(parser)
+    args = parser.parse_args()
+    val = get_config_value(args)
+    print(val, end='')
+
+
+if __name__ == "__main__":
+    main()

--- a/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
+++ b/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
@@ -11,6 +11,15 @@
     shell: |
       docker volume prune -f
 
+  - name: Stop tester container if running
+    when: ovn_tester is defined
+    ignore_errors: yes
+    shell: |
+      cd {{ ovn_fake_multinode_target_path }}/ovn-fake-multinode
+      ./ovs-docker del-ports br-ovn ovn-tester
+      ./ovs-docker del-ports br-ovn-ext ovn-tester
+      docker rm -f --volumes ovn-tester
+
   - name: Delete old docker containers if any
     shell: |
       set -e

--- a/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
+++ b/ovn-fake-multinode-utils/playbooks/deploy-minimal.yml
@@ -15,9 +15,6 @@
     when: ovn_tester is defined
     ignore_errors: yes
     shell: |
-      cd {{ ovn_fake_multinode_target_path }}/ovn-fake-multinode
-      ./ovs-docker del-ports br-ovn ovn-tester
-      ./ovs-docker del-ports br-ovn-ext ovn-tester
       docker rm -f --volumes ovn-tester
 
   - name: Delete old docker containers if any

--- a/ovn-fake-multinode-utils/playbooks/pull-ovn-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/pull-ovn-tester.yml
@@ -1,0 +1,9 @@
+- name: Install ovn-tester
+  hosts: ovn_hosts
+  tasks:
+    - name: Pull latest containers
+      when: ovn_tester is defined
+      shell: |
+              set -e
+              docker pull {{ registry_node }}:5000/ovn/ovn-tester
+              docker tag {{ registry_node }}:5000/ovn/ovn-tester ovn/ovn-tester

--- a/ovn-fake-multinode-utils/playbooks/pull-ovn-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/pull-ovn-tester.yml
@@ -6,4 +6,3 @@
       shell: |
               set -e
               docker pull {{ registry_node }}:5000/ovn/ovn-tester
-              docker tag {{ registry_node }}:5000/ovn/ovn-tester ovn/ovn-tester

--- a/ovn-fake-multinode-utils/playbooks/run-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/run-tester.yml
@@ -7,6 +7,17 @@
     shell: |
       docker run -dt --name=ovn-tester --hostname=ovn-tester --privileged ovn/ovn-tester
 
+  - name: Copy physical deployment file to tester host
+    when: ovn_tester is defined
+    copy:
+      src: "{{ phys_deployment }}"
+      dest: /tmp/physical-deployment.yml
+
+  - name: Copy physical deployment file to tester container
+    when: ovn_tester is defined
+    shell: |
+      docker cp /tmp/physical-deployment.yml ovn-tester:/physical-deployment.yml
+
   - name: Copy test file to tester host
     when: ovn_tester is defined
     ansible.builtin.copy:

--- a/ovn-fake-multinode-utils/playbooks/run-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/run-tester.yml
@@ -1,0 +1,20 @@
+- name: Run the tester
+  hosts: ovn_hosts
+  become: true
+  tasks:
+  - name: Start tester container
+    when: ovn_tester is defined
+    shell: |
+      docker run -dt --name=ovn-tester --hostname=ovn-tester --privileged ovn/ovn-tester
+
+  - name: Copy files to the tester container
+    when: ovn_tester is defined
+    shell: |
+      docker cp {{ test_file }} ovn-tester:/test-scenario.yml
+
+  - name: Add tester container interfaces to OVS bridges
+    when: ovn_tester is defined
+    shell: |
+      cd {{ ovn_fake_multinode_target_path }}/ovn-fake-multinode
+      ./ovs-docker add-port br-ovn eth1 ovn-tester --ipaddress={{ tester_ip }}
+      ./ovs-docker add-port br-ovn-ext eth2 ovn-tester

--- a/ovn-fake-multinode-utils/playbooks/run-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/run-tester.yml
@@ -28,7 +28,7 @@
   - name: Start process monitor
     when: ovn_tester is defined
     shell: |
-      nohup python3 /tmp/process-monitor.py \
+      docker exec ovn-tester bash -c "nohup python3 /tmp/process-monitor.py \
       -s ovn-tester \
       -o /var/log/process-stats.json \
-      -x /tmp/process-monitor.exit &
+      -x /tmp/process-monitor.exit </dev/null >/dev/null 2>&1 &"

--- a/ovn-fake-multinode-utils/playbooks/run-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/run-tester.yml
@@ -10,7 +10,7 @@
   - name: Copy test file to tester host
     when: ovn_tester is defined
     ansible.builtin.copy:
-      src: {{ test_file }}
+      src: "{{ test_file }}"
       dest: /tmp/test-scenario.yml
 
   - name: Copy files to the tester container

--- a/ovn-fake-multinode-utils/playbooks/run-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/run-tester.yml
@@ -7,10 +7,16 @@
     shell: |
       docker run -dt --name=ovn-tester --hostname=ovn-tester --privileged ovn/ovn-tester
 
+  - name: Copy test file to tester host
+    when: ovn_tester is defined
+    ansible.builtin.copy:
+      src: {{ test_file }}
+      dest: /tmp/test-scenario.yml
+
   - name: Copy files to the tester container
     when: ovn_tester is defined
     shell: |
-      docker cp {{ test_file }} ovn-tester:/test-scenario.yml
+      docker cp /tmp/test-scenario.yml ovn-tester:/test-scenario.yml
 
   - name: Add tester container interfaces to OVS bridges
     when: ovn_tester is defined

--- a/ovn-fake-multinode-utils/playbooks/run-tester.yml
+++ b/ovn-fake-multinode-utils/playbooks/run-tester.yml
@@ -24,3 +24,11 @@
       cd {{ ovn_fake_multinode_target_path }}/ovn-fake-multinode
       ./ovs-docker add-port br-ovn eth1 ovn-tester --ipaddress={{ tester_ip }}
       ./ovs-docker add-port br-ovn-ext eth2 ovn-tester
+
+  - name: Start process monitor
+    when: ovn_tester is defined
+    shell: |
+      nohup python3 /tmp/process-monitor.py \
+      -s ovn-tester \
+      -o /var/log/process-stats.json \
+      -x /tmp/process-monitor.exit &

--- a/ovn-fake-multinode-utils/process-monitor.py
+++ b/ovn-fake-multinode-utils/process-monitor.py
@@ -21,6 +21,12 @@ def monitor(suffix, out_file, exit_file):
             for p in psutil.process_iter():
                 if any(name in p.name() for name in process_names):
                     processes.add(p)
+                elif any(
+                    name in part
+                    for part in p.cmdline()
+                    for name in process_names
+                ):
+                    processes.add(p)
 
             if len(processes) == 0:
                 time.sleep(0.5)

--- a/ovn-fake-multinode-utils/scripts/log-collector.sh
+++ b/ovn-fake-multinode-utils/scripts/log-collector.sh
@@ -50,6 +50,7 @@ for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-tester"); do
     docker exec $c bash -c 'touch /tmp/process-monitor.exit && sleep 5'
     docker exec $c bash -c "mkdir -p /htmls; cp -f /*.html /htmls"
     docker cp $c:/htmls/. ${host}/$c/
+    docker cp $c:/var/log/process-stats.json ${host}/$c/
 done
 
 journalctl --since "8 hours ago" -a > ${host}/messages

--- a/ovn-fake-multinode-utils/scripts/log-collector.sh
+++ b/ovn-fake-multinode-utils/scripts/log-collector.sh
@@ -45,6 +45,12 @@ for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-relay"); do
     docker cp $c:/var/log/process-stats.json ${host}/$c/
 done
 
+for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-tester"); do
+    mkdir ${host}/$c
+    docker exec $c bash -c "mkdir -p /htmls; cp -f /*.html /htmls"
+    docker cp $c:/htmls/. ${host}/$c/
+done
+
 journalctl --since "8 hours ago" -a > ${host}/messages
 
 tar cvfz ${host}.tgz ${host}

--- a/ovn-fake-multinode-utils/scripts/log-collector.sh
+++ b/ovn-fake-multinode-utils/scripts/log-collector.sh
@@ -47,6 +47,7 @@ done
 
 for c in $(docker ps --format "{{.Names}}" --filter "name=ovn-tester"); do
     mkdir ${host}/$c
+    docker exec $c bash -c 'touch /tmp/process-monitor.exit && sleep 5'
     docker exec $c bash -c "mkdir -p /htmls; cp -f /*.html /htmls"
     docker cp $c:/htmls/. ${host}/$c/
 done

--- a/ovn-fake-multinode-utils/translate_yaml.py
+++ b/ovn-fake-multinode-utils/translate_yaml.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Dict
+import yaml
+import netaddr
+import sys
+
+
+def load_yaml(orig_yaml_file_name):
+    with open(orig_yaml_file_name, "r") as orig_yaml_file:
+        return yaml.safe_load(orig_yaml_file)
+
+
+@dataclass
+class GlobalConfig:
+    log_cmds: bool = False
+    cleanup: bool = False
+    run_ipv4: bool = True
+    run_ipv6: bool = False
+
+
+def calculate_node_remotes(
+    node_net: str, clustered_db: bool, n_relays: int, enable_ssl: bool
+) -> str:
+    net = netaddr.IPNetwork(node_net)
+
+    ip_gen = net.iter_hosts()
+    if n_relays > 0:
+        skip = 3 if clustered_db else 1
+        for _ in range(0, skip):
+            next(ip_gen)
+        ip_range = range(0, n_relays)
+    else:
+        ip_range = range(0, 3 if clustered_db else 1)
+    if enable_ssl:
+        remotes = ["ssl:" + str(next(ip_gen)) + ":6642" for _ in ip_range]
+    else:
+        remotes = ["tcp:" + str(next(ip_gen)) + ":6642" for _ in ip_range]
+    return ','.join(remotes)
+
+
+DEFAULT_N_VIPS = 2
+DEFAULT_VIP_PORT = 80
+
+
+def calculate_vips(subnet: str) -> Dict:
+    vip_subnet = netaddr.IPNetwork(subnet)
+    vip_gen = vip_subnet.iter_hosts()
+    vip_range = range(0, DEFAULT_N_VIPS)
+    prefix = '[' if vip_subnet.version == 6 else ''
+    suffix = ']' if vip_subnet.version == 6 else ''
+    return {
+        f'{prefix}{next(vip_gen)}{suffix}:{DEFAULT_VIP_PORT}': None
+        for _ in vip_range
+    }
+
+
+DEFAULT_N_STATIC_VIPS = 65
+DEFAULT_N_STATIC_BACKENDS = 2
+DEFAULT_STATIC_BACKEND_SUBNET = netaddr.IPNetwork('6.0.0.0/8')
+DEFAULT_STATIC_BACKEND_SUBNET6 = netaddr.IPNetwork('6::/32')
+DEFAULT_BACKEND_PORT = 8080
+
+
+def calculate_static_vips(vip_subnet: str) -> Dict:
+    vip_subnet = netaddr.IPNetwork(vip_subnet)
+    if vip_subnet.version == 6:
+        backend_subnet = DEFAULT_STATIC_BACKEND_SUBNET6
+    else:
+        backend_subnet = DEFAULT_STATIC_BACKEND_SUBNET
+
+    vip_gen = vip_subnet.iter_hosts()
+    vip_range = range(0, DEFAULT_N_STATIC_VIPS)
+
+    backend_gen = backend_subnet.iter_hosts()
+    backend_range = range(0, DEFAULT_N_STATIC_BACKENDS)
+
+    prefix = '[' if vip_subnet.version == 6 else ''
+    suffix = ']' if vip_subnet.version == 6 else ''
+
+    # This assumes it's OK to use the same backend list for each
+    # VIP. If we need to use different backends for each VIP,
+    # then this will need to be updated
+    backend_list = [
+        f'{prefix}{next(backend_gen)}{suffix}:{DEFAULT_BACKEND_PORT}'
+        for _ in backend_range
+    ]
+
+    return {
+        f'{prefix}{next(vip_gen)}{suffix}:{DEFAULT_VIP_PORT}': backend_list
+        for _ in vip_range
+    }
+
+
+@dataclass
+class ClusterConfig:
+    cluster_cmd_path: str = '/root/ovn-heater/runtime/ovn-fake-multinode'
+    monitor_all: bool = True
+    logical_dp_groups: bool = True
+    clustered_db: bool = True
+    datapath_type: str = "system"
+    raft_election_to: int = 16
+    northd_probe_interval: int = 5000
+    northd_threads: int = 4
+    db_inactivity_probe: int = 60000
+    node_net: str = "192.16.0.0/16"
+    enable_ssl: bool = True
+    node_remote: str = None
+    node_timeout_s: int = 20
+    internal_net: str = "16.0.0.0/16"
+    internal_net6: str = "16::/64"
+    external_net: str = "3.0.0.0/16"
+    external_net6: str = "3::/64"
+    gw_net: str = "2.0.0.0/16"
+    gw_net6: str = "2::/64"
+    cluster_net: str = "16.0.0.0/4"
+    cluster_net6: str = "16::/32"
+    n_workers: int = 2
+    n_relays: int = 0
+    vips: Dict = None
+    vips6: Dict = None
+    vip_subnet: str = "4.0.0.0/8"
+    vip_subnet6: str = "4::/32"
+    static_vips: Dict = None
+    static_vips6: Dict = None
+    use_ovsdb_etcd: bool = False
+
+    def __post_init__(self, **kwargs):
+        # Some defaults have to be calculated
+        if not self.node_remote:
+            self.node_remote = calculate_node_remotes(
+                self.node_net,
+                self.clustered_db,
+                self.n_relays,
+                self.enable_ssl,
+            )
+
+        if not self.vips:
+            self.vips = calculate_vips(self.vip_subnet)
+
+        if not self.vips6:
+            self.vips6 = calculate_vips(self.vip_subnet6)
+
+        if not self.static_vips:
+            self.static_vips = calculate_static_vips(self.vip_subnet)
+
+        if not self.static_vips6:
+            self.static_vips6 = calculate_static_vips(self.vip_subnet6)
+
+
+def translate_yaml(orig_yaml):
+    global_cfg = GlobalConfig(**orig_yaml["global"])
+    cluster_cfg = ClusterConfig(**orig_yaml["cluster"])
+
+    dest_yaml = dict()
+    dest_yaml["global"] = vars(global_cfg)
+    dest_yaml["cluster"] = vars(cluster_cfg)
+
+    for section, values in orig_yaml.items():
+        if section != "global" and section != "cluster":
+            dest_yaml[section] = values
+
+    return dest_yaml
+
+
+def write_yaml(dest_yaml, dest_yaml_file_name):
+    with open(dest_yaml_file_name, "w") as dest_yaml_file:
+        yaml.dump(dest_yaml, dest_yaml_file)
+
+
+def main():
+    orig_yaml_file_name = Path(sys.argv[1])
+    dest_yaml_file_name = Path(sys.argv[2])
+
+    orig_yaml = load_yaml(orig_yaml_file_name)
+    dest_yaml = translate_yaml(orig_yaml)
+    write_yaml(dest_yaml, dest_yaml_file_name)
+
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -286,7 +286,7 @@ def configure_tests(yaml, central_node, worker_nodes, global_cfg):
 
 def create_nodes(cluster_config, central, workers):
     mgmt_net = cluster_config.node_net
-    mgmt_ip = mgmt_net.ip + 1
+    mgmt_ip = mgmt_net.ip + 2
     internal_net = cluster_config.internal_net
     external_net = cluster_config.external_net
     gw_net = cluster_config.gw_net

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -6,6 +6,7 @@ import netaddr
 import yaml
 import importlib
 import ovn_exceptions
+import gc
 
 from collections import namedtuple
 from ovn_context import Context
@@ -247,6 +248,9 @@ def read_config(config):
 def setup_logging(global_cfg):
     FORMAT = '%(asctime)s | %(name)-12s |%(levelname)s| %(message)s'
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
+
+    if gc.isenabled():
+        gc.set_debug(gc.DEBUG_STATS)
 
     if not global_cfg.log_cmds:
         return

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -19,7 +19,7 @@ from ovn_utils import DualStackSubnet
 from ovs.stream import Stream
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("ovn_tester")
 
 
 DEFAULT_VIP_SUBNET = netaddr.IPNetwork('4.0.0.0/8')
@@ -255,7 +255,8 @@ def setup_logging(global_cfg):
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
 
     if gc.isenabled():
-        gc.set_debug(gc.DEBUG_STATS)
+        gc.disable()
+        gc.set_threshold(0)
 
     if not global_cfg.log_cmds:
         return

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -252,6 +252,16 @@ def setup_logging(global_cfg):
     logging.Formatter.converter = time.gmtime
 
     if gc.isenabled():
+        # If the garbage collector is enabled, it runs from time to time, and
+        # interrupts ovn-tester to do so. If we are timing an operation, then
+        # the gc can distort the amount of time something actually takes to
+        # complete, resulting in graphs with spikes.
+        #
+        # Disabling the garbage collector runs the theoretical risk of leaking
+        # a lot of memory, but in practical tests, this has not been a
+        # problem. If gigantic-scale tests end up introducing memory issues,
+        # then we may want to manually run the garbage collector between test
+        # iterations or between test runs.
         gc.disable()
         gc.set_threshold(0)
 

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -7,6 +7,7 @@ import yaml
 import importlib
 import ovn_exceptions
 import gc
+import time
 
 from collections import namedtuple
 from ovn_context import Context
@@ -248,6 +249,7 @@ def read_config(config):
 def setup_logging(global_cfg):
     FORMAT = '%(asctime)s | %(name)-12s |%(levelname)s| %(message)s'
     logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
+    logging.Formatter.converter = time.gmtime
 
     if gc.isenabled():
         gc.disable()

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -13,9 +13,8 @@ from ovn_sandbox import PhysicalNode
 from ovn_workload import BrExConfig, ClusterConfig
 from ovn_workload import CentralNode, WorkerNode, Cluster
 from ovn_utils import DualStackSubnet
+from ovs.stream import Stream
 
-FORMAT = '%(asctime)s | %(name)-12s |%(levelname)s| %(message)s'
-logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
 
 DEFAULT_VIP_SUBNET = netaddr.IPNetwork('4.0.0.0/8')
 DEFAULT_VIP_SUBNET6 = netaddr.IPNetwork('4::/32')
@@ -117,6 +116,12 @@ def read_physical_deployment(deployment, global_cfg):
             for worker in dep['worker-nodes']
         ]
         return central_node, worker_nodes
+
+
+# SSL files are installed by ovn-fake-multinode in these locations.
+SSL_KEY_FILE = "/opt/ovn/ovn-privkey.pem"
+SSL_CERT_FILE = "/opt/ovn/ovn-cert.pem"
+SSL_CACERT_FILE = "/opt/ovn/pki/switchca/cacert.pem"
 
 
 def read_config(config):
@@ -224,6 +229,9 @@ def read_config(config):
         static_vips6=static_vips6,
         use_ovsdb_etcd=cluster_args.get('use_ovsdb_etcd', False),
         northd_threads=cluster_args.get('northd_threads', 4),
+        ssl_private_key=SSL_KEY_FILE,
+        ssl_cert=SSL_CERT_FILE,
+        ssl_cacert=SSL_CACERT_FILE,
     )
     brex_cfg = BrExConfig(
         physical_net=cluster_args.get('physical_net', 'providernet'),
@@ -234,6 +242,20 @@ def read_config(config):
         n_pods_per_node=bringup_args.get('n_pods_per_node', 10)
     )
     return global_cfg, cluster_cfg, brex_cfg, bringup_cfg
+
+
+def setup_logging(global_cfg):
+    FORMAT = '%(asctime)s | %(name)-12s |%(levelname)s| %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FORMAT)
+
+    if not global_cfg.log_cmds:
+        return
+
+    modules = [
+        "ovsdbapp.backend.ovs_idl.transaction",
+    ]
+    for module_name in modules:
+        logging.getLogger(module_name).setLevel(logging.DEBUG)
 
 
 RESERVED = [
@@ -290,7 +312,15 @@ def create_nodes(cluster_config, central, workers):
     return central_node, worker_nodes
 
 
+def set_ssl_keys(cluster_cfg):
+    Stream.ssl_set_private_key_file(cluster_cfg.ssl_private_key)
+    Stream.ssl_set_certificate_file(cluster_cfg.ssl_cert)
+    Stream.ssl_set_ca_cert_file(cluster_cfg.ssl_cacert)
+
+
 def prepare_test(central_node, worker_nodes, cluster_cfg, brex_cfg):
+    if cluster_cfg.enable_ssl:
+        set_ssl_keys(cluster_cfg)
     ovn = Cluster(central_node, worker_nodes, cluster_cfg, brex_cfg)
     with Context(ovn, "prepare_test"):
         ovn.start()
@@ -321,6 +351,8 @@ if __name__ == '__main__':
         config = yaml.safe_load(yaml_file)
 
     global_cfg, cluster_cfg, brex_cfg, bringup_cfg = read_config(config)
+
+    setup_logging(global_cfg)
 
     if not global_cfg.run_ipv4 and not global_cfg.run_ipv6:
         raise ovn_exceptions.OvnInvalidConfigException()

--- a/ovn-tester/ovn_tester.py
+++ b/ovn-tester/ovn_tester.py
@@ -6,9 +6,7 @@ import netaddr
 import yaml
 import importlib
 import ovn_exceptions
-import subprocess
 import gc
-import shlex
 
 from collections import namedtuple
 from ovn_context import Context
@@ -17,9 +15,6 @@ from ovn_workload import BrExConfig, ClusterConfig
 from ovn_workload import CentralNode, WorkerNode, Cluster
 from ovn_utils import DualStackSubnet
 from ovs.stream import Stream
-
-
-log = logging.getLogger("ovn_tester")
 
 
 DEFAULT_VIP_SUBNET = netaddr.IPNetwork('4.0.0.0/8')
@@ -352,17 +347,6 @@ def run_base_cluster_bringup(ovn, bringup_cfg, global_cfg):
         ovn.provision_lb_group()
 
 
-def start_process_monitor(container):
-    log.info(f'Starting process monitor for {container}')
-    cmd = shlex.split(
-        f'bash -c "nohup python3 /tmp/process-monitor.py '
-        f'-s {container} '
-        f'-o /var/log/process-stats.json '
-        f'-x /tmp/process-monitor.exit"'
-    )
-    subprocess.Popen(cmd)
-
-
 if __name__ == '__main__':
     if len(sys.argv) != 3:
         usage(sys.argv[0])
@@ -381,8 +365,6 @@ if __name__ == '__main__':
     central, workers = read_physical_deployment(sys.argv[1], global_cfg)
     central_node, worker_nodes = create_nodes(cluster_cfg, central, workers)
     tests = configure_tests(config, central_node, worker_nodes, global_cfg)
-
-    start_process_monitor("ovn-tester")
 
     ovn = prepare_test(central_node, worker_nodes, cluster_cfg, brex_cfg)
     run_base_cluster_bringup(ovn, bringup_cfg, global_cfg)

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -245,7 +245,7 @@ class OvsVsctl:
         self.run(f'ip netns del {lport.name}', prefix='')
 
 
-LLONG_MAX = 2 ** 63 - 1
+LLONG_MAX = 2**63 - 1
 
 
 # We have to subclass the base Transaction for NB in order to facilitate the
@@ -283,7 +283,11 @@ class NBTransaction(transaction.Transaction):
     def pre_commit(self, txn):
         if self.wait_type:
             if self.api._nb.nb_cfg == LLONG_MAX:
-                txn.add(self.api.db_set("NB_Global", self.api._nb.uuid, ("nb_cfg", 0)))
+                txn.add(
+                    self.api.db_set(
+                        "NB_Global", self.api._nb.uuid, ("nb_cfg", 0)
+                    )
+                )
             self.api._nb.increment('nb_cfg')
 
     def post_commit(self, txn):

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -356,7 +356,7 @@ class OvnNbctl:
         self.idl.db_set(
             "Connection",
             self.idl._connection.uuid,
-            ("inactivity_probe", str(value)),
+            ("inactivity_probe", value),
         ).execute()
 
     def lr_add(self, name):
@@ -580,7 +580,7 @@ class OvnNbctl:
         ).execute()
 
     def lb_set_vips(self, lb, vips):
-        vips = dict((k, ",".join(str(v))) for k, v in vips.items())
+        vips = dict((k, ",".join(v)) for k, v in vips.items())
         self.idl.db_set("Load_Balancer", lb.uuid, ("vips", vips)).execute()
 
     def lb_clear_vips(self, lb):
@@ -636,7 +636,7 @@ class OvnSbctl:
         self.idl.db_set(
             "Connection",
             self.idl._connection.uuid,
-            ("inactivity_probe", str(value)),
+            ("inactivity_probe", value),
         ).execute()
 
     def chassis_bound(self, chassis=""):

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -2,9 +2,9 @@ import logging
 import netaddr
 import ovn_exceptions
 from collections import namedtuple
-from io import StringIO
 import ovsdbapp.schema.open_vswitch.impl_idl as ovs_impl_idl
 import ovsdbapp.schema.ovn_northbound.impl_idl as nb_impl_idl
+import ovsdbapp.schema.ovn_southbound.impl_idl as sb_impl_idl
 from ovsdbapp.backend import ovs_idl
 from ovsdbapp.backend.ovs_idl import connection
 from ovsdbapp.backend.ovs_idl import transaction
@@ -608,22 +608,33 @@ class OvnNbctl:
             pass
 
 
-class OvnSbctl:
-    def __init__(self, sb):
-        self.sb = sb
+class SBIdl(sb_impl_idl.OvnSbApiIdlImpl, Backend):
+    def __init__(self, connection):
+        super(SBIdl, self).__init__(connection)
 
-    def run(self, cmd="", stdout=None, timeout=DEFAULT_CTL_TIMEOUT):
-        self.sb.run(
-            cmd="ovn-sbctl --no-leader-only " + cmd,
-            stdout=stdout,
-            timeout=timeout,
+    @property
+    def _connection(self):
+        # Shortcut to retrieve the lone Connection record. This is used by
+        # NBTransaction for synchronization purposes.
+        return next(iter(self.db_list_rows('Connection').execute()))
+
+
+class OvnSbctl:
+    def __init__(self, sb, connection_string, inactivity_probe):
+        i = connection.OvsdbIdl.from_server(
+            connection_string, "OVN_Southbound"
         )
+        c = connection.Connection(i, inactivity_probe)
+        self.idl = SBIdl(c)
 
     def set_inactivity_probe(self, value):
-        self.run(f'set Connection . inactivity_probe={value}')
+        self.idl.db_set(
+            "Connection",
+            self.idl._connection.uuid,
+            ("inactivity_probe", value),
+        ).execute()
 
     def chassis_bound(self, chassis=""):
-        cmd = f'--bare --columns _uuid find chassis name={chassis}'
-        stdout = StringIO()
-        self.run(cmd=cmd, stdout=stdout)
-        return len(stdout.getvalue().splitlines()) == 1
+        cmd = self.idl.db_find_rows("Chassis", ("name", "=", chassis))
+        cmd.execute()
+        return len(cmd.result) == 1

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -1,5 +1,6 @@
 import logging
 import netaddr
+import select
 import ovn_exceptions
 from collections import namedtuple
 import ovsdbapp.schema.open_vswitch.impl_idl as ovs_impl_idl
@@ -11,6 +12,7 @@ from ovsdbapp.backend.ovs_idl import idlutils
 from ovsdbapp.backend.ovs_idl import transaction
 from ovsdbapp.backend.ovs_idl import vlog
 from ovsdbapp import exceptions as ovsdbapp_exceptions
+from ovs import poller
 
 
 log = logging.getLogger(__name__)
@@ -48,6 +50,7 @@ DualStackIP = namedtuple('DualStackIP', ['ip4', 'plen4', 'ip6', 'plen6'])
 
 
 vlog.use_python_logger(max_level=vlog.INFO)
+poller.SelectPoll = select.poll
 
 
 class PhysCtl:

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -245,6 +245,9 @@ class OvsVsctl:
         self.run(f'ip netns del {lport.name}', prefix='')
 
 
+LLONG_MAX = 2 ** 63 - 1
+
+
 # We have to subclass the base Transaction for NB in order to facilitate the
 # "sync" command. This is heavily based on ovsdbapp's OvsVsctlTransaction class
 # but with some NB-specific modifications, and removal of some OVS-specific
@@ -279,6 +282,8 @@ class NBTransaction(transaction.Transaction):
 
     def pre_commit(self, txn):
         if self.wait_type:
+            if self.api._nb.nb_cfg == LLONG_MAX:
+                txn.add(self.api.db_set("NB_Global", self.api._nb.uuid, ("nb_cfg", 0)))
             self.api._nb.increment('nb_cfg')
 
     def post_commit(self, txn):

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -54,6 +54,11 @@ DualStackIP = namedtuple('DualStackIP', ['ip4', 'plen4', 'ip6', 'plen6'])
 
 
 vlog.use_python_logger(max_level=vlog.INFO)
+
+# Under the hood, ovsdbapp uses select.select, but it has a hard-coded limit
+# on the number of file descriptors that can be selected from. In large-scale
+# tests (500 nodes), we exceed this number and run into issues. By switching to
+# select.poll, we do not have this limitation.
 poller.SelectPoll = select.poll
 
 

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -4,8 +4,11 @@ import ovn_exceptions
 from collections import namedtuple
 from io import StringIO
 import ovsdbapp.schema.open_vswitch.impl_idl as ovs_impl_idl
+import ovsdbapp.schema.ovn_northbound.impl_idl as nb_impl_idl
 from ovsdbapp.backend import ovs_idl
 from ovsdbapp.backend.ovs_idl import connection
+from ovsdbapp.backend.ovs_idl import transaction
+from ovsdbapp import exceptions as ovsdbapp_exceptions
 
 
 log = logging.getLogger(__name__)
@@ -225,60 +228,164 @@ class OvsVsctl:
         self.run(f'ip netns del {lport.name}', prefix='')
 
 
+# We have to subclass the base Transaction for NB in order to facilitate the
+# "sync" command. This is heavily based on ovsdbapp's OvsVsctlTransaction class
+# but with some NB-specific modifications, and removal of some OVS-specific
+# assumptions.
+class NBTransaction(transaction.Transaction):
+    def __init__(
+        self,
+        api,
+        ovsdb_connection,
+        timeout=None,
+        check_error=False,
+        log_errors=True,
+        wait_type=None,
+        **kwargs,
+    ):
+        super(NBTransaction, self).__init__(
+            api,
+            ovsdb_connection,
+            timeout=timeout,
+            check_error=check_error,
+            log_errors=log_errors,
+            **kwargs,
+        )
+        self.wait_type = wait_type.lower() if wait_type else None
+        if (
+            self.wait_type
+            and self.wait_type != "sb"
+            and self.wait_type != "hv"
+        ):
+            log.warning(f"Unrecognized wait type {self.wait_type}. Ignoring")
+            self.wait_type = None
+
+    def pre_commit(self, txn):
+        if self.wait_type:
+            self.api._nb.increment('nb_cfg')
+
+    def post_commit(self, txn):
+        super().post_commit(txn)
+        try:
+            self.do_post_commit(txn)
+        except ovsdbapp_exceptions.TimeoutException:
+            log.exception("Transaction timed out")
+
+    def do_post_commit(self, txn):
+        if not self.wait_type:
+            return
+
+        next_cfg = txn.get_increment_new_value()
+        while not self.timeout_exceeded():
+            self.api.idl.run()
+            if self.nb_has_completed(next_cfg):
+                break
+            self.ovsdb_connection.poller.timer_wait(
+                self.time_remaining() * 1000
+            )
+            self.api.idl.wait(self.ovsdb_connection.poller)
+            self.ovsdb_connection.poller.block()
+        else:
+            raise ovsdbapp_exceptions.TimeoutException(
+                commands=self.commands,
+                timeout=self.timeout,
+                cause='nbctl transaction did not end',
+            )
+
+    def nb_has_completed(self, next_cfg):
+        if not self.wait_type:
+            return True
+        elif self.wait_type == "sb":
+            cur_cfg = self.api._nb.sb_cfg
+        else:  # self.wait_type == "hv":
+            cur_cfg = min(self.api._nb.sb_cfg, self.api._nb.hv_cfg)
+
+        return cur_cfg >= next_cfg
+
+
+class NBIdl(nb_impl_idl.OvnNbApiIdlImpl, Backend):
+    def __init__(self, connection):
+        super(NBIdl, self).__init__(connection)
+
+    def create_transaction(
+        self,
+        check_error=False,
+        log_errors=True,
+        timeout=None,
+        wait_type=None,
+        **kwargs,
+    ):
+        # Override of Base API method so we create NBTransactions.
+        return NBTransaction(
+            self,
+            self.ovsdb_connection,
+            timeout=timeout,
+            check_error=check_error,
+            log_errors=log_errors,
+            wait_type=wait_type,
+            **kwargs,
+        )
+
+    @property
+    def _nb(self):
+        return next(iter(self.db_list_rows('NB_Global').execute()))
+
+    @property
+    def _connection(self):
+        return next(iter(self.db_list_rows('Connection').execute()))
+
+
 class OvnNbctl:
-    def __init__(self, sb):
-        self.sb = sb
-        self.socket = ""
-
-    def __del__(self):
-        # FIXME: the SSH connection might have already been closed here..
-        # self.stop_daemon()
-        pass
-
-    def run(self, cmd="", stdout=None, timeout=DEFAULT_CTL_TIMEOUT):
-        prefix = "ovn-nbctl "
-        if len(self.socket):
-            prefix = prefix + "-u " + self.socket + " "
-        self.sb.run(cmd=prefix + cmd, stdout=stdout, timeout=timeout)
+    def __init__(self, sb, connection_string, inactivity_probe):
+        i = connection.OvsdbIdl.from_server(
+            connection_string, "OVN_Northbound"
+        )
+        c = connection.Connection(i, inactivity_probe)
+        self.idl = NBIdl(c)
 
     def set_global(self, option, value):
-        self.run(f'set NB_Global . options:{option}={value}')
+        self.idl.db_set(
+            "NB_Global", self.idl._nb.uuid, ("options", {option: value})
+        ).execute()
 
     def set_inactivity_probe(self, value):
-        self.run(f'set Connection . inactivity_probe={value}')
+        self.idl.db_set(
+            "Connection",
+            self.idl._connection.uuid,
+            ("inactivity_probe", value),
+        ).execute()
 
     def lr_add(self, name):
         log.info(f'Creating lrouter {name}')
 
-        cmd = f'create Logical_Router name={name}'
-        stdout = StringIO()
-        self.run(cmd=cmd, stdout=stdout)
-        return LRouter(name=name, uuid=stdout.getvalue().strip())
+        add_cmd = self.idl.lr_add(name)
+        add_cmd.execute()
+        return LRouter(name=name, uuid=add_cmd.result.uuid)
 
     def lr_port_add(self, router, name, mac, dual_ip=None):
-        cmd = f'lrp-add {router.uuid} {name} {mac}'
+        networks = []
         if dual_ip.ip4 and dual_ip.plen4:
-            cmd += f' {dual_ip.ip4}/{dual_ip.plen4} '
+            networks.append(f'{dual_ip.ip4}/{dual_ip.plen4}')
         if dual_ip.ip6 and dual_ip.plen6:
-            cmd += f' {dual_ip.ip6}/{dual_ip.plen6} '
-        self.run(cmd=cmd)
+            networks.append(f'{dual_ip.ip6}/{dual_ip.plen6}')
+
+        self.idl.lrp_add(router.uuid, name, str(mac), networks).execute()
         return LRPort(name=name, mac=mac, ip=dual_ip)
 
     def lr_port_set_gw_chassis(self, rp, chassis, priority=10):
         log.info(f'Setting gw chassis {chassis} for router port {rp.name}')
-        self.run(cmd=f'lrp-set-gateway-chassis {rp.name} {chassis} {priority}')
+        self.idl.lrp_set_gateway_chassis(rp.name, chassis, priority).execute()
 
     def ls_add(self, name, net_s):
         log.info(f'Creating lswitch {name}')
 
-        cmd = f'create Logical_Switch name={name}'
-        stdout = StringIO()
-        self.run(cmd=cmd, stdout=stdout)
+        cmd = self.idl.ls_add(name)
+        cmd.execute()
         return LSwitch(
             name=name,
             cidr=net_s.n4,
             cidr6=net_s.n6,
-            uuid=stdout.getvalue().strip(),
+            uuid=cmd.result.uuid,
         )
 
     def ls_port_add(
@@ -295,13 +402,11 @@ class OvnNbctl:
         security=False,
         localnet=False,
     ):
-        cmd = f'lsp-add {lswitch.uuid} {name}'
+        columns = dict()
         if router_port:
-            cmd += (
-                f' -- lsp-set-type {name} router'
-                f' -- lsp-set-addresses {name} router'
-                f' -- lsp-set-options {name} router-port={router_port.name}'
-            )
+            columns["type"] = "router"
+            columns["addresses"] = "router"
+            columns["options"] = {"router-port": router_port.name}
         elif mac or ip or localnet:
             addresses = []
             if mac:
@@ -314,13 +419,14 @@ class OvnNbctl:
                 addresses.append(str(ip.ip6))
 
             addresses = " ".join(addresses)
-            cmd += f' -- lsp-set-addresses {name} \"{addresses}\"'
+
+            columns["addresses"] = addresses
             if security:
-                cmd += f' -- lsp-set-port-security {name} \"{addresses}\"'
-        self.run(cmd=cmd)
-        stdout = StringIO()
-        self.run(cmd=f'get logical_switch_port {name} _uuid', stdout=stdout)
-        uuid = stdout.getvalue().strip()
+                columns["port_security"] = addresses
+
+        add_cmd = self.idl.lsp_add(lswitch.uuid, name, **columns)
+        add_cmd.execute()
+        uuid = add_cmd.result.uuid
 
         ip4 = "unknown" if localnet else ip.ip4 if ip else None
         plen4 = ip.plen4 if ip else None
@@ -349,55 +455,55 @@ class OvnNbctl:
         )
 
     def ls_port_del(self, port):
-        self.run(cmd=f'lsp-del {port.name}')
+        self.idl.lsp_del(port.name).execute()
 
     def ls_port_set_set_options(self, port, options):
-        self.run(cmd=f'lsp-set-options {port.name} {options}')
+        opts = dict(
+            (k, v)
+            for k, v in (element.split("=") for element in options.split())
+        )
+        self.idl.lsp_set_options(port.name, **opts).execute()
 
     def ls_port_set_set_type(self, port, lsp_type):
-        self.run(cmd=f'lsp-set-type {port.name} {lsp_type}')
+        self.idl.lsp_set_type(port.name, lsp_type).execute()
 
     def port_group_create(self, name):
-        self.run(cmd=f'create port_group name={name}')
+        self.idl.pg_add(name).execute()
         return PortGroup(name=name)
 
     def port_group_add(self, pg, lport):
-        self.run(cmd=f'add port_group {pg.name} ports {lport.uuid}')
+        self.idl.pg_add_ports(pg.name, lport.uuid).execute()
 
     def port_group_add_ports(self, pg, lports):
         MAX_PORTS_IN_BATCH = 500
         for i in range(0, len(lports), MAX_PORTS_IN_BATCH):
             lports_slice = lports[i : i + MAX_PORTS_IN_BATCH]
-            port_uuids = " ".join(p.uuid for p in lports_slice)
-            self.run(cmd=f'add port_group {pg.name} ports {port_uuids}')
+            port_uuids = [p.uuid for p in lports_slice]
+            self.idl.pg_add_ports(pg.name, port_uuids).execute()
 
     def port_group_del(self, pg):
-        self.run(cmd=f'destroy port_group {pg.name}')
+        self.idl.pg_del(pg.name).execute()
 
     def address_set_create(self, name):
-        self.run(cmd=f'create address_set name={name}')
+        self.idl.address_set_add(name).execute()
         return AddressSet(name=name)
 
     def address_set_add(self, addr_set, addr):
-        cmd = f'add Address_Set {addr_set.name} addresses \'\"{addr}\"\''
-        self.run(cmd=cmd)
+        self.idl.address_set_add_addresses(addr_set.name, addr)
 
     def address_set_add_addrs(self, addr_set, addrs):
         MAX_ADDRS_IN_BATCH = 500
         for i in range(0, len(addrs), MAX_ADDRS_IN_BATCH):
-            addrs_slice = [
-                f'\"{a}\"' for a in addrs[i : i + MAX_ADDRS_IN_BATCH]
-            ]
-            addrs_str = ','.join(addrs_slice)
-            cmd = f'add Address_Set {addr_set.name} addresses \'{addrs_str}\''
-            self.run(cmd=cmd)
+            addrs_slice = [str(a) for a in addrs[i : i + MAX_ADDRS_IN_BATCH]]
+            self.idl.address_set_add_addresses(
+                addr_set.name, addrs_slice
+            ).execute()
 
     def address_set_remove(self, addr_set, addr):
-        cmd = f'remove Address_Set {addr_set.name} addresses \'\"{addr}\"\''
-        self.run(cmd=cmd)
+        self.idl.address_set_remove_addresses(addr_set.name, addr)
 
     def address_set_del(self, addr_set):
-        self.run(cmd=f'destroy Address_Set {addr_set.name}')
+        self.idl.address_set_del(addr_set.name)
 
     def acl_add(
         self,
@@ -408,123 +514,98 @@ class OvnNbctl:
         match="",
         verdict="allow",
     ):
-        self.run(
-            cmd=f'--type={entity} acl-add {name} '
-            f'{direction} {priority} "{match}" {verdict}'
-        )
+        if entity == "switch":
+            self.idl.acl_add(name, direction, priority, match, verdict)
+        else:  # "port-group"
+            self.idl.pg_acl_add(name, direction, priority, match, verdict)
 
-    def route_add(self, router, network, gw, policy=None):
-        prefix = f'--policy={policy} ' if policy else ''
+    def route_add(self, router, network, gw, policy="dst-ip"):
         if network.n4 and gw.ip4:
-            self.run(
-                cmd=f'{prefix} lr-route-add {router.uuid} '
-                f'{network.n4} {gw.ip4}'
-            )
+            self.idl.lr_route_add(
+                router.uuid, network.n4, gw.ip4, policy=policy
+            ).execute()
         if network.n6 and gw.ip6:
-            self.run(
-                cmd=f'{prefix} lr-route-add {router.uuid} '
-                f'{network.n6} {gw.ip6}'
-            )
+            self.idl.lr_route_add(
+                router.uuid, network.n6, gw.ip6, policy=policy
+            ).execute()
 
     def nat_add(self, router, external_ip, logical_net, nat_type="snat"):
         if external_ip.ip4 and logical_net.n4:
-            self.run(
-                cmd=f'lr-nat-add {router.uuid} '
-                f'{nat_type} {external_ip.ip4} '
-                f'{logical_net.n4}'
-            )
+            self.idl.lr_nat_add(
+                router.uuid, nat_type, external_ip.ip4, logical_net.n4
+            ).execute()
         if external_ip.ip6 and logical_net.n6:
-            self.run(
-                cmd=f'lr-nat-add {router.uuid} '
-                f'{nat_type} {external_ip.ip6} '
-                f'{logical_net.n6}'
-            )
+            self.idl.lr_nat_add(
+                router.uuid, nat_type, external_ip.ip6, logical_net.n6
+            ).execute()
 
     def create_lb(self, name, protocol):
         lb_name = f"{name}-{protocol}"
-        cmd = f"create Load_Balancer name={lb_name} protocol={protocol}"
-
-        stdout = StringIO()
-        self.run(cmd=cmd, stdout=stdout)
-        return LoadBalancer(name=lb_name, uuid=stdout.getvalue().strip())
+        # We can't use ovsdbapp's lb_add here because it is not possible to
+        # create a load balancer with no VIPs.
+        cmd = self.idl.db_create(
+            "Load_Balancer", name=lb_name, protocol=protocol
+        )
+        cmd.execute()
+        return LoadBalancer(name=lb_name, uuid=cmd.result)
 
     def create_lbg(self, name):
-        cmd = f'create Load_Balancer_Group name={name}'
-        stdout = StringIO()
-        self.run(cmd=cmd, stdout=stdout)
-        return LoadBalancerGroup(name=name, uuid=stdout.getvalue().strip())
+        cmd = self.idl.db_create("Load_Balancer_Group", name=name)
+        cmd.execute()
+        return LoadBalancerGroup(name=name, uuid=cmd.result)
 
     def lbg_add_lb(self, lbg, lb):
-        cmd = f'add Load_Balancer_Group {lbg.uuid} load_balancer {lb.uuid}'
-        self.run(cmd=cmd)
+        self.idl.db_add(
+            "Load_Balancer_Group", lbg.uuid, "load_balancer", lb.uuid
+        ).execute()
 
     def ls_add_lbg(self, ls, lbg):
-        cmd = f'add Logical_Switch {ls.uuid} load_balancer_group {lbg.uuid}'
-        self.run(cmd=cmd)
+        self.idl.db_add(
+            "Logical_Switch", ls.uuid, "load_balancer_group", lbg.uuid
+        ).execute()
 
     def lr_add_lbg(self, lr, lbg):
-        cmd = f'add Logical_Router {lr.uuid} load_balancer_group {lbg.uuid}'
-        self.run(cmd=cmd)
+        self.idl.db_add(
+            "Logical_Router", lr.uuid, "load_balancer_group", lbg.uuid
+        ).execute()
 
     def lr_set_options(self, router, options):
-        opt = ''
-        for key, value in options.items():
-            opt = opt + f' options:{key}={value}'
-
-        self.run(f'set Logical_Router {router.name} {opt}')
+        self.idl.db_set(
+            "Logical_Router", router.uuid, ("options", options)
+        ).execute()
 
     def lb_set_vips(self, lb, vips):
-        vip_str = ''
-        for vip, backends in vips.items():
-            vip_str += f'vips:\\"{vip}\\"=\\"{",".join(backends)}\\" '
-        cmd = f"set Load_Balancer {lb.uuid} {vip_str}"
-        self.run(cmd=cmd)
+        vips = dict((k, ",".join(v)) for k, v in vips.items())
+        self.idl.db_set("Load_Balancer", lb.uuid, ("vips", vips)).execute()
 
     def lb_clear_vips(self, lb):
-        self.run(cmd=f'clear Load_Balancer {lb.uuid} vips')
+        self.idl.db_clear("Load_Balancer", lb.uuid, "vips").execute()
 
     def lb_add_to_routers(self, lb, routers):
-        cmd = ' -- '.join([f'lr-lb-add {r} {lb.uuid}' for r in routers])
-        self.run(cmd=cmd)
+        with self.idl.transaction(check_error=True) as txn:
+            for r in routers:
+                txn.add(self.idl.lr_lb_add(r, lb.uuid))
 
     def lb_add_to_switches(self, lb, switches):
-        cmd = ' -- '.join([f'ls-lb-add {s} {lb.uuid}' for s in switches])
-        self.run(cmd=cmd)
+        with self.idl.transaction(check_error=True) as txn:
+            for s in switches:
+                txn.add(self.idl.ls_lb_add(s, lb.uuid))
 
     def lb_remove_from_routers(self, lb, routers):
-        cmd = ' -- '.join([f'lr-lb-del {r} {lb.uuid}' for r in routers])
-        self.run(cmd=cmd)
+        with self.idl.transaction(check_error=True) as txn:
+            for r in routers:
+                txn.add(self.idl.lr_lb_del(r, lb.uuid))
 
     def lb_remove_from_switches(self, lb, switches):
-        cmd = ' -- '.join([f'ls-lb-del {s} {lb.uuid}' for s in switches])
-        self.run(cmd=cmd)
-
-    def wait_until(self, cmd=""):
-        self.run("wait-until " + cmd)
+        with self.idl.transaction(check_error=True) as txn:
+            for s in switches:
+                txn.add(self.idl.ls_lb_del(s, lb.uuid))
 
     def sync(self, wait="hv", timeout=DEFAULT_CTL_TIMEOUT):
-        self.run(
-            f'--timeout={timeout} --wait={wait} sync', timeout=(timeout + 1)
-        )
-
-    def start_daemon(self, nb_cluster_ips, enable_ssl):
-        if enable_ssl:
-            remote = ','.join([f'ssl:{ip}:6641' for ip in nb_cluster_ips])
-        else:
-            remote = ','.join([f'tcp:{ip}:6641' for ip in nb_cluster_ips])
-        # FIXME: hardcoded args, are these really an issue?
-        cmd = (
-            f'--detach --pidfile --log-file --db={remote} '
-            f'-p /opt/ovn/ovn-privkey.pem -c /opt/ovn/ovn-cert.pem '
-            f'-C /opt/ovn/pki/switchca/cacert.pem'
-        )
-        stdout = StringIO()
-        self.run(cmd=cmd, stdout=stdout)
-        self.socket = stdout.getvalue().rstrip()
-
-    def stop_daemon(self):
-        if len(self.socket):
-            self.sb.run(cmd=f'ovs-appctl -t {self.socket} exit')
+        with self.idl.transaction(
+            check_error=True, timeout=timeout, wait_type=wait
+        ):
+            pass
 
 
 class OvnSbctl:

--- a/ovn-tester/ovn_workload.py
+++ b/ovn-tester/ovn_workload.py
@@ -781,7 +781,7 @@ class Cluster(object):
         self.cluster_cfg = cluster_cfg
         self.brex_cfg = brex_cfg
         self.nbctl = None
-        self.sbctl = ovn_utils.OvnSbctl(self.central_node)
+        self.sbctl = None
         self.net = cluster_cfg.cluster_net
         self.router = None
         self.load_balancer = None
@@ -800,6 +800,12 @@ class Cluster(object):
             self.central_node, nb_conn, inactivity_probe
         )
 
+        sb_conn = self.central_node.get_connection_string(
+            self.cluster_cfg, 6642
+        )
+        self.sbctl = ovn_utils.OvnSbctl(
+            self.central_node, sb_conn, inactivity_probe
+        )
         for w in self.worker_nodes:
             w.start(self.cluster_cfg)
             w.configure(self.brex_cfg.physical_net)

--- a/ovn-tester/requirements.txt
+++ b/ovn-tester/requirements.txt
@@ -5,3 +5,4 @@ pandas
 plotly
 pyyaml
 randmac
+git+https://github.com/openstack/ovsdbapp@master#egg=ovsdbapp

--- a/physical-deployments/ci.yml
+++ b/physical-deployments/ci.yml
@@ -1,12 +1,12 @@
-registry-node: <ip>
+registry-node: <host>
 internal-iface: lo
 
 central-node:
-  name: <ip>
+  name: <host>
 
 tester-node:
-  name: <ip>
+  name: <host>
   ssh_key: /root/.ssh/id_rsa
 
 worker-nodes:
-  - <ip>
+  - <host>

--- a/physical-deployments/ci.yml
+++ b/physical-deployments/ci.yml
@@ -1,0 +1,12 @@
+registry-node: <ip>
+internal-iface: eno1
+
+central-node:
+  name: <ip>
+
+tester-node:
+  name: <ip>
+  ssh_key: /root/.ssh/id_rsa
+
+worker-nodes:
+  - <ip>

--- a/physical-deployments/ci.yml
+++ b/physical-deployments/ci.yml
@@ -1,5 +1,5 @@
 registry-node: <ip>
-internal-iface: eno1
+internal-iface: lo
 
 central-node:
   name: <ip>

--- a/physical-deployments/localhost.yml
+++ b/physical-deployments/localhost.yml
@@ -1,8 +1,0 @@
-registry-node: localhost
-internal-iface: lo
-
-central-node:
-  name: localhost
-
-worker-nodes:
-  - localhost

--- a/physical-deployments/physical-deployment.yml
+++ b/physical-deployments/physical-deployment.yml
@@ -6,7 +6,7 @@ central-node:
 
 tester-node:
   name: host02.mydoman.com
-  ssh-key: id_rsa
+  ssh_key: id_rsa
 
 worker-nodes:
   - host03.mydomain.com

--- a/physical-deployments/physical-deployment.yml
+++ b/physical-deployments/physical-deployment.yml
@@ -6,7 +6,7 @@ central-node:
 
 tester-node:
   name: host02.mydoman.com
-  ssh_key: id_rsa
+  ssh_key: /path/to/ssh_key
 
 worker-nodes:
   - host03.mydomain.com

--- a/physical-deployments/physical-deployment.yml
+++ b/physical-deployments/physical-deployment.yml
@@ -4,6 +4,10 @@ internal-iface: eno1
 central-node:
   name: host02.mydomain.com
 
+tester-node:
+  name: host02.mydoman.com
+  ssh-key: id_rsa
+
 worker-nodes:
   - host03.mydomain.com
   - host04.mydomain.com

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+pandas
+plotly


### PR DESCRIPTION
In the pull request to use ovsdbapp [1] the issue [2] was raised that both `do.sh` and `ovn_tester.py` had duplicated a default value. It means that if that default were to change, we would need to update it in multiple places. This change implements the suggestion made by @igsilya to translate the test scenario YAML file into a YAML file with all defaults filled in.

Supposedly this change applies to the main branch of ovn-heater as-is, but I developed this in a branch based on PR 136, so it would be best if this went in after the ovsdbapp change was made.

[1] https://github.com/dceara/ovn-heater/pull/136
[2] https://github.com/dceara/ovn-heater/pull/136#discussion_r1008006173