### PR TITLE
Update python and black version on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 black==22.3.0
+        python -m pip install flake8 black==22.12.0
     # Ignore E203, W503 and W504 which is against PEP 8 style
     - name: flake8
       run: |


### PR DESCRIPTION
The python 3.6 is no longer available with
latest Ubuntu (22.04.1) on Github actions.