### PR TITLE
ovn-tester: Disable neighbor_responder flows for LB VIPs on LR.

### DIFF
--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -608,6 +608,7 @@ class OvnNbctl:
             "Load_Balancer",
             name=lb_name,
             protocol=protocol,
+            options={"neighbor_responder": "none"},
             get_func=partial(self.idl.lb_get, lb_name),
         )
         return LoadBalancer(name=lb_name, uuid=uuid)


### PR DESCRIPTION
ovn-kubernetes disables this option since:
  https://github.com/ovn-org/ovn-kubernetes/pull/3400