### PR TITLE
ovn-tester: Align LB options with ovn-kubernetes.

### DIFF
--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -608,7 +608,13 @@ class OvnNbctl:
             "Load_Balancer",
             name=lb_name,
             protocol=protocol,
-            options={"neighbor_responder": "none"},
+            options={
+                "reject": "true",
+                "event": "false",
+                "skip_snat": "false",
+                "hairpin_snat_ip": "169.254.169.5 fd69::5",  # magic IPs.
+                "neighbor_responder": "none",
+            },
             get_func=partial(self.idl.lb_get, lb_name),
         )
         return LoadBalancer(name=lb_name, uuid=uuid)


### PR DESCRIPTION
Setting all LB options the same way ovn-kuberneted does in a default configuration according to buildLB() function:
  https://github.com/ovn-org/ovn-kubernetes/blob/a7e9e693db1b5c963655112257df112c80e1cbfe/go-controller/pkg/ovn/controller/services/loadbalancer.go#L293

The main impact might be from the 'reject' option that alters northd behavior in a few places.