### PR TITLE
cirrus: Fail CI if there are python stack traces in the log.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,6 +51,8 @@ low_scale_task:
 
   check_logs_script:
     - '! grep -B 30 -A 30 "Result: FAIL" ./test_results/*/test-log'
+    - '! grep -B 30 -A 30 "Traceback" ./test_results/*/test-log'
+    - '! grep "Failed to run test" ./test_results/*/test-log'
     - grep "Result: SUCCESS" ./test_results/*/test-log
 
   always:


### PR DESCRIPTION
If the test script fails, it doesn't fail with an error code. It continues to gather logs and mine data, so we have a clean exit code in the end.

We look for iteration failures afterwards, but we don't look for hard failures in python code.

Fix that by grepping for python 'Traceback' and failing if it is found.