### PR TITLE
ovn-tester: Fix miscalculated node remotes.

### DIFF
--- a/ovn-fake-multinode-utils/translate_yaml.py
+++ b/ovn-fake-multinode-utils/translate_yaml.py
@@ -31,6 +31,8 @@ def calculate_node_remotes(
     net = netaddr.IPNetwork(node_net)
 
     ip_gen = net.iter_hosts()
+    # The first IP is assigned to the tester, skip it.
+    next(ip_gen)
     if n_relays > 0:
         skip = 3 if clustered_db else 1
         for _ in range(0, skip):

--- a/ovn-tester/ovn_utils.py
+++ b/ovn-tester/ovn_utils.py
@@ -183,6 +183,7 @@ class VSIdl(ovs_impl_idl.OvsdbIdl, Backend):
 
 class OvsVsctl:
     def __init__(self, sb, connection_string, inactivity_probe):
+        log.info(f'OvsVsctl: {connection_string}, probe: {inactivity_probe}')
         self.sb = sb
         i = connection.OvsdbIdl.from_server(connection_string, "Open_vSwitch")
         c = connection.Connection(i, inactivity_probe)
@@ -367,6 +368,7 @@ class UUIDTransactionError(Exception):
 
 class OvnNbctl:
     def __init__(self, sb, connection_string, inactivity_probe):
+        log.info(f'OvnNbctl: {connection_string}, probe: {inactivity_probe}')
         i = connection.OvsdbIdl.from_server(
             connection_string, "OVN_Northbound"
         )
@@ -708,6 +710,7 @@ class SBIdl(sb_impl_idl.OvnSbApiIdlImpl, Backend):
 
 class OvnSbctl:
     def __init__(self, sb, connection_string, inactivity_probe):
+        log.info(f'OvnSbctl: {connection_string}, probe: {inactivity_probe}')
         i = BaseOvnSbIdl.from_server(connection_string)
         c = connection.Connection(i, inactivity_probe)
         self.idl = SBIdl(c)


### PR DESCRIPTION
ovn-tester is currently using .1, .2 and .3 IP addresses as ovn-remote while actual database servers are on .2, .3 and .4.  This is happening because calculate_default_node_remotes() doesn't take into account the tester itself that owns the .1 address.

Fixes: 4ad22627749c ("Use the first IP address in the node_net for the tester.")