### PR TITLE
install-fake-multinode.yml: Copy ovn-fake-multinode from the orchestrator.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,8 @@ low_scale_task:
     memory: 8G
 
   env:
-    DEPENDENCIES: git ansible podman podman-docker
+    DEPENDENCIES: git ansible ansible-collection-ansible-posix
+                  podman podman-docker
     PHYS_DEPLOYMENT: ${CIRRUS_WORKING_DIR}/physical-deployments/ci.yml
 
   runtime_cache:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ not resolve to a unique host.
 
 ### Install required packages:
 ```
-dnf install -y git ansible
+dnf install -y git ansible ansible-collection-ansible-posix
 ```
 
 ## Minimal requirements on the TESTER node (tested on Fedora 36)

--- a/do.sh
+++ b/do.sh
@@ -163,13 +163,15 @@ OS_IMAGE_OVERRIDE="${OS_IMAGE_OVERRIDE}"
 
 function install_ovn_fake_multinode() {
     echo "-- Cloning ${ovn_fmn_repo} on all nodes, revision ${ovn_fmn_branch}"
-    # Clone repo on all hosts.
-    ansible-playbook ${ovn_fmn_playbooks}/install-fake-multinode.yml -i ${hosts_file}
 
     local rebuild_needed=0
 
     # Clone repo locally
     clone_component ovn-fake-multinode ${ovn_fmn_repo} ${ovn_fmn_branch} || rebuild_needed=1
+
+    # Copy repo to all hosts.
+    ansible-playbook ${ovn_fmn_playbooks}/install-fake-multinode.yml -i ${hosts_file} \
+        --extra-vars="ovn_fake_multinode_local_path=${rundir}/ovn-fake-multinode"
 
     if [ -n "$RPM_OVS" ]
     then

--- a/ovn-fake-multinode-utils/playbooks/install-fake-multinode.yml
+++ b/ovn-fake-multinode-utils/playbooks/install-fake-multinode.yml
@@ -6,18 +6,9 @@
         path: "{{ ovn_fake_multinode_target_path }}"
         state: directory
 
-    - name: Remove old ovn-fake-multinode remote installation
-      file:
-        path: "{{ ovn_fake_multinode_target_path }}/ovn-fake-multinode"
-        state: absent
-
-    - name: Clone ovn-fake-multinode
-      shell: |
-              set -e
-              cd {{ ovn_fake_multinode_target_path }}
-              git clone {{ ovn_fake_multinode_repo }}
-              cd ovn-fake-multinode
-              git remote set-url origin {{ ovn_fake_multinode_repo }}
-              git fetch origin
-              git checkout {{ ovn_fake_multinode_branch }}
-              git pull
+    - name: Sync ovn-fake-multinode
+      ansible.posix.synchronize:
+        src: "{{ ovn_fake_multinode_local_path }}"
+        dest: "{{ ovn_fake_multinode_target_path }}"
+        delete: true
+        recursive: true


### PR DESCRIPTION
Instead of cloning the same repo from each physical host it can be copied from the orchestrator node, where we already have it.

Simultaneous git clone from multiple physical nodes frequently results in GitHub connection timeouts.