### PR TITLE
Fix ovn-tester python version and issues uncovered in CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ low_scale_task:
   compute_engine_instance:
     matrix:
       - image_project: fedora-cloud
-        image: family/fedora-cloud-38
+        image: family/fedora-cloud-43-x86-64
       - image_project: ubuntu-os-cloud
         image: family/ubuntu-2404-lts-amd64
     platform: linux

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,8 +7,9 @@ low_scale_task:
       - image_project: ubuntu-os-cloud
         image: family/ubuntu-2404-lts-amd64
     platform: linux
-    memory: 8G
+    memory: 16G
     disk: 40
+    cpu: 4
 
   env:
     DEPENDENCIES: git ansible podman

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ovn/ovn-multi-node
 
 ARG SSH_KEY
 
+COPY utils/helpers.sh /scripts/helpers.sh
 COPY ovn-tester /ovn-tester
 
 RUN mkdir -p /root/.ssh/
@@ -9,8 +10,10 @@ COPY $SSH_KEY /root/.ssh/
 
 COPY ovn-fake-multinode-utils/process-monitor.py /tmp/
 
+RUN /bin/bash -c ". /scripts/helpers.sh; install_latest_python"
+
 # This variable is needed on systems where global python's
 # environment is marked as "Externally managed" (PEP 668) to allow pip
 # installation of "global" packages.
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-RUN pip3 install -r /ovn-tester/requirements.txt
+RUN python3 -m pip install -r /ovn-tester/requirements.txt

--- a/do.sh
+++ b/do.sh
@@ -107,9 +107,7 @@ function generate() {
 
 function install_deps_local_rpm() {
     echo "-- Installing local dependencies"
-    yum install redhat-lsb-core datamash \
-        python3-netaddr python3 python3-devel \
-        podman \
+    yum install datamash python3-netaddr python3 python3-devel podman \
         --skip-broken -y
 }
 

--- a/do.sh
+++ b/do.sh
@@ -30,70 +30,7 @@ ovn_tester=${topdir}/ovn-tester
 EXTRA_OPTIMIZE=${EXTRA_OPTIMIZE:-no}
 USE_OVSDB_ETCD=${USE_OVSDB_ETCD:-no}
 
-# We want values from both the `ID` and `ID_LIKE` fields to ensure successful
-# categorization.  The shell will happily accept both spaces and newlines as
-# separators:
-# https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
-DISTRO_IDS=$(awk -F= '/^ID/{print$2}' /etc/os-release | tr -d '"')
-
-DISTRO_VERSION_ID=$(awk -F= '/^VERSION_ID/{print$2}' /etc/os-release | tr -d '"')
-
-function is_rpm_based() {
-    for id in $DISTRO_IDS; do
-        case $id in
-        centos* | rhel* | fedora*)
-            true
-            return
-        ;;
-        esac
-    done
-    false
-}
-
-function is_rhel() {
-    for id in $DISTRO_IDS; do
-        case $id in
-        centos* | rhel*)
-            true
-            return
-        ;;
-        esac
-    done
-    false
-}
-
-function is_fedora() {
-    for id in $DISTRO_IDS; do
-        case $id in
-        fedora*)
-            true
-            return
-        ;;
-        esac
-    done
-    false
-}
-
-function is_deb_based() {
-    for id in $DISTRO_IDS; do
-        case $id in
-        debian* | ubuntu*)
-            true
-            return
-            ;;
-        esac
-    done
-    false
-}
-
-function die() {
-    echo $1
-    exit 1
-}
-
-function die_distro() {
-    die "Unable to determine distro type, rpm- and deb-based are supported."
-}
+source $topdir/utils/helpers.sh
 
 function generate() {
     # Make sure rundir exists.

--- a/ovn-fake-multinode-utils/generate-hosts.py
+++ b/ovn-fake-multinode-utils/generate-hosts.py
@@ -19,22 +19,26 @@ where DEPLOYMENT is the YAML file defining the deployment.
     )
 
 
-def generate_node_string(host: str, **kwargs) -> None:
+def generate_node_string(
+    host: str, internal_iface: str | None, **kwargs
+) -> None:
+    if internal_iface is not None:
+        kwargs['internal_iface'] = internal_iface
     args = ' '.join(f"{key}={value}" for key, value in kwargs.items())
     print(f"{host} {args}")
 
 
-def generate_node(config: Dict, internal_iface: str, **kwargs) -> None:
+def generate_node(config: Dict, internal_iface: str | None, **kwargs) -> None:
     host: str = config['name']
     internal_iface = config.get('internal-iface', internal_iface)
     generate_node_string(
         host,
-        internal_iface=internal_iface,
+        internal_iface,
         **kwargs,
     )
 
 
-def generate_tester(config: Dict, internal_iface: str) -> None:
+def generate_tester(config: Dict, internal_iface: str | None) -> None:
     ssh_key = config["ssh_key"]
     ssh_key = Path(ssh_key).resolve()
     generate_node(
@@ -45,7 +49,7 @@ def generate_tester(config: Dict, internal_iface: str) -> None:
     )
 
 
-def generate_nodes(nodes_config: Dict, internal_iface: str, **kwargs):
+def generate_nodes(nodes_config: Dict, internal_iface: str | None, **kwargs):
     for node_config in nodes_config:
         host, node_config = helpers.get_node_config(node_config)
         iface = node_config.get('internal-iface', internal_iface)
@@ -62,7 +66,7 @@ def generate(input_file: str, target: str, repo: str, branch: str) -> None:
         user = config.get('user', 'root')
         prefix = config.get('prefix', 'ovn-scale')
         tester_config = config['tester-node']
-        internal_iface = config['internal-iface']
+        internal_iface = config.get('internal-iface')
 
         print('[tester_hosts]')
         generate_tester(tester_config, internal_iface)

--- a/physical-deployments/ci.yml
+++ b/physical-deployments/ci.yml
@@ -1,5 +1,3 @@
-internal-iface: lo
-
 central-nodes:
   - <host>
 

--- a/utils/helpers.sh
+++ b/utils/helpers.sh
@@ -1,0 +1,84 @@
+# We want values from both the `ID` and `ID_LIKE` fields to ensure successful
+# categorization.  The shell will happily accept both spaces and newlines as
+# separators:
+# https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_05
+DISTRO_IDS=$(awk -F= '/^ID/{print$2}' /etc/os-release | tr -d '"')
+
+DISTRO_VERSION_ID=$(awk -F= '/^VERSION_ID/{print$2}' /etc/os-release | tr -d '"')
+
+function is_rpm_based() {
+    for id in $DISTRO_IDS; do
+        case $id in
+        centos* | rhel* | fedora*)
+            true
+            return
+        ;;
+        esac
+    done
+    false
+}
+
+function is_rhel() {
+    for id in $DISTRO_IDS; do
+        case $id in
+        centos* | rhel*)
+            true
+            return
+        ;;
+        esac
+    done
+    false
+}
+
+function is_fedora() {
+    for id in $DISTRO_IDS; do
+        case $id in
+        fedora*)
+            true
+            return
+        ;;
+        esac
+    done
+    false
+}
+
+function is_deb_based() {
+    for id in $DISTRO_IDS; do
+        case $id in
+        debian* | ubuntu*)
+            true
+            return
+            ;;
+        esac
+    done
+    false
+}
+
+# Installs the most recent available python3 and pip version for the
+# current distro.
+function install_latest_python() {
+    if is_rhel
+    then
+        py_pkg=$(dnf list available 'python3.[0-9][0-9]' -q 2> /dev/null |
+                 grep -o '^python3.[0-9][0-9]' | sort -V | tail -n 1) &&
+        dnf install -y ${py_pkg}-pip &&
+        alternatives --install /usr/bin/python3 python3 /usr/bin/$py_pkg 100
+    elif is_fedora
+    then
+        dnf install -y python3-pip
+    elif is_deb_based
+    then
+        apt install -y python3-pip
+    else
+        die_distro
+    fi
+}
+
+function die() {
+    echo $1
+    exit 1
+}
+
+function die_distro() {
+    die "Unable to determine distro type, rpm- and deb-based are supported."
+}


### PR DESCRIPTION
If we don't use the latest available Python version other packages we need might fail to install.  E.g., ovsdbapp requires Python >= 3.10:

  ERROR: Package 'ovsdbapp' requires a different Python: 3.9.25 not in '>=3.10'
  Error: building at STEP "RUN pip3 install -r /ovn-tester/requirements.txt":
  while running runtime: exit status 1

While testing this change a bunch of other issues were uncovered, mostly due to our CI failing to run after recent changes to various components.  This PR also fixes those issues:
- skip installation redhat-lsb-core (not needed)
- try setting RAFT election timeout on all DB cluster members (the first one is not always the elected leader)
- support optional internal-iface configuration (for single node deployments)
- moved to Fedora:43 in CI as Fedora:38 is EOL for a long time
- fix incorrect handling of vt100 String Terminator control characters
- increase the VM memory size for CirrusCI runs (we're running out of memory on Ubuntu VMs due to non-OVN processes being pulled in by default in the Ubuntu container image)